### PR TITLE
EmbeddingTest is unable to locate test data.

### DIFF
--- a/test/src/edu/stanford/nlp/neural/EmbeddingTest.java
+++ b/test/src/edu/stanford/nlp/neural/EmbeddingTest.java
@@ -14,10 +14,9 @@ import org.junit.Test;
  */
 
 public class EmbeddingTest {
-  public static final String PREFIX = "projects/core/";
-  public static final String wordVectorFile = PREFIX + "data/edu/stanford/nlp/neural/wordVector.txt";
-  public static final String wordFile = PREFIX + "data/edu/stanford/nlp/neural/word.txt";
-  public static final String vectorFile = PREFIX + "data/edu/stanford/nlp/neural/vector.txt";
+  public static final String wordVectorFile = "data/edu/stanford/nlp/neural/wordVector.txt";
+  public static final String wordFile = "data/edu/stanford/nlp/neural/word.txt";
+  public static final String vectorFile = "data/edu/stanford/nlp/neural/vector.txt";
   
   @Test
   public void testLoadFromOneFile() {


### PR DESCRIPTION
EmbeddingTest is unable to locate test data. Removing the prefix fixes this.
