### PR TITLE
Tweak CLAUSAL_PASSIVE_SUBJECT's long name.

### DIFF
--- a/src/edu/stanford/nlp/trees/EnglishGrammaticalRelations.java
+++ b/src/edu/stanford/nlp/trees/EnglishGrammaticalRelations.java
@@ -434,7 +434,7 @@ public class EnglishGrammaticalRelations {
    * "That she lied was suspected by everyone" &rarr; <code>csubjpass</code>(suspected, lied)
    */
   public static final GrammaticalRelation CLAUSAL_PASSIVE_SUBJECT =
-    new GrammaticalRelation(Language.English, "csubjpass", "clausal subject",
+    new GrammaticalRelation(Language.English, "csubjpass", "clausal passive subject",
         ClausalPassiveSubjectGRAnnotation.class, CLAUSAL_SUBJECT, "S", tregexCompiler,
         new String[] {
           "S < (SBAR|S=target !$+ /^,$/ $++ (VP < (VP < VBN|VBD) < (/^(?:VB|AUXG?)/ < " + passiveAuxWordRegex + ") !$-- NP))",


### PR DESCRIPTION
Minor change to give CLAUSAL_SUBJECT and CLAUSAL_PASSIVE_SUBJECT distinct long names.
