### PR TITLE
Added a command line option to print singleton entities.

### DIFF
--- a/src/edu/stanford/nlp/pipeline/StanfordCoreNLP.java
+++ b/src/edu/stanford/nlp/pipeline/StanfordCoreNLP.java
@@ -217,6 +217,10 @@ public class StanfordCoreNLP extends AnnotationPipeline {
     return properties.getProperty("encoding", "UTF-8");
   }
 
+  public boolean getPrintSingletons() {
+    return PropertiesUtils.getBool(properties, "printable.printSingletonEntities", false); 
+  }
+
   public static boolean isXMLOutputPresent() {
     try {
       Class clazz = Class.forName("edu.stanford.nlp.pipeline.XMLOutputter");

--- a/src/edu/stanford/nlp/pipeline/StanfordCoreNLP.properties
+++ b/src/edu/stanford/nlp/pipeline/StanfordCoreNLP.properties
@@ -56,6 +56,7 @@ annotators = tokenize, ssplit, pos, lemma, ner, parse, dcoref
 #dcoref.female = /scr/nlp/data/Bergsma-Gender/female.unigrams.txt
 #dcoref.plural = /scr/nlp/data/Bergsma-Gender/plural.unigrams.txt
 #dcoref.singular = /scr/nlp/data/Bergsma-Gender/singular.unigrams.txt
+#printable.printSingletonEntities = false
 
 # This is the regular expression that describes which xml tags to keep
 # the text from.  In order to on off the xml removal, add cleanxml

--- a/src/edu/stanford/nlp/pipeline/XMLOutputter.java
+++ b/src/edu/stanford/nlp/pipeline/XMLOutputter.java
@@ -51,6 +51,8 @@ public class XMLOutputter {
     public String encoding = "UTF-8";
     /** How to print a constituent tree */
     public TreePrint constituentTreePrinter = DEFAULT_CONSTITUENT_TREE_PRINTER;
+    /** Print only non-singleton entities*/
+    public boolean printSingletons = false;
   }
 
   /**
@@ -61,6 +63,7 @@ public class XMLOutputter {
     options.relationsBeam = pipeline.getBeamPrintingOption();
     options.constituentTreePrinter = pipeline.getConstituentTreePrinter();
     options.encoding = pipeline.getEncoding();
+    options.printSingletons = pipeline.getPrintSingletons();
     return options;
   }
 
@@ -325,7 +328,7 @@ public class XMLOutputter {
   {
     boolean foundCoref = false;
     for (CorefChain chain : corefChains.values()) {
-      if (chain.getMentionsInTextualOrder().size() <= 1)
+      if (!options.printSingletons && chain.getMentionsInTextualOrder().size() <= 1)
         continue;
       foundCoref = true;
       Element chainElem = new Element("coreference", curNS);


### PR DESCRIPTION
For some processing tasks, you really want to identify _all_ entities, even 
those with only one mention. 

Invoke this option by the property

```
printable.printSingletonEntities = true
```

By default, this is set to <tt>false</tt>: the current behavior, of printing only
non-singleton entities, is respected.

All unit tests pass; this is public domain.
