### PR TITLE
Fix a bug in OWLQN: use raw gradient to calculate y vectors

### DIFF
--- a/src/edu/stanford/nlp/optimization/QNMinimizer.java
+++ b/src/edu/stanford/nlp/optimization/QNMinimizer.java
@@ -912,7 +912,7 @@ public class QNMinimizer implements Minimizer<DiffFunction>, HasEvaluators {
       noHistory = false;
     }
 
-    double[] x, newX, grad, newGrad, dir;
+    double[] x, newX, rawGrad, grad, newGrad, dir;
     double value;
     its = 0;
     fevals = 0;
@@ -924,19 +924,20 @@ public class QNMinimizer implements Minimizer<DiffFunction>, HasEvaluators {
     x = initial;
 
     // initialize gradient
-    grad = new double[x.length];
+    rawGrad = new double[x.length];
     newGrad = new double[x.length];
     newX = new double[x.length];
     dir = new double[x.length];
 
     // initialize function value and gradient (gradient is stored in grad inside
     // evaluateFunction)
-    value = evaluateFunction(dFunction, x, grad);
+    value = evaluateFunction(dFunction, x, rawGrad);
     if (useOWLQN) {
       double norm = l1NormOWL(x, dFunction);
       value += norm * lambdaOWL;
-      grad = pseudoGradientOWL(x, grad, dFunction); // step (1) in Galen & Gao except we are not computing v yet
-    }
+      // step (1) in Galen & Gao except we are not computing v yet
+      grad = pseudoGradientOWL(x, rawGrad, dFunction);
+    } else grad = rawGrad;
 
     PrintWriter outFile = null;
     PrintWriter infoFile = null;
@@ -958,7 +959,7 @@ public class QNMinimizer implements Minimizer<DiffFunction>, HasEvaluators {
 
     Record rec = new Record(quiet, monitor, functionTolerance, outFile);
     // sets the original gradient and x. Also stores the monitor.
-    rec.start(value, grad, x);
+    rec.start(value, rawGrad, x);
 
     // Check if max Evaluations and Iterations have been provided.
     maxFevals = (maxFunctionEvaluations > 0) ? maxFunctionEvaluations
@@ -1049,9 +1050,10 @@ public class QNMinimizer implements Minimizer<DiffFunction>, HasEvaluators {
         System.arraycopy(dFunction.derivativeAt(newX), 0, newGrad, 0, newGrad.length);
 
         // This is where all the s, y updates are applied.
-        qn.update(newX, x, newGrad, grad, newPoint[a]); // step (4) in Galen & Gao 2007
+        qn.update(newX, x, newGrad, rawGrad, newPoint[a]); // step (4) in Galen & Gao 2007
 
         if (useOWLQN) {
+          System.arraycopy(newGrad, 0, rawGrad, 0, newGrad.length);
           // pseudo gradient
           newGrad = pseudoGradientOWL(newX, newGrad, dFunction);
         }


### PR DESCRIPTION
The gradient used to construct the y_k vectors, should be raw gradient (the gradient of the unregularized loss). See "Scalable Training of L1-Regularized Log-Linear Models" Section 3.2 rule 4.