### PR TITLE
XMLTag errantly writes debug info to standard out

### DIFF
--- a/src/edu/stanford/nlp/util/XMLUtils.java
+++ b/src/edu/stanford/nlp/util/XMLUtils.java
@@ -1029,7 +1029,7 @@ public class XMLUtils {
               if (end < 0) {
                 end = tag.length();
               }
-              System.out.println(begin + " " + end);
+              // System.out.println("unqouted begin, end: " + begin + ", " + end);
               value = tag.substring(begin, end);
             }
           }


### PR DESCRIPTION
There is a debug statement writing to standard out that should be commented out.  Normally I do not like checking in commented out code, but this seems to be a convention that is accepted in this file. 

This causes problems for extensions of CoreNLP that rely on piping standard out to other programs.  I stumbled across this using https://github.com/hazyresearch/deepdive which uses the CleanXML annotator (which uses the XMLUtils.XMLTag) by default in their example code.