### PR TITLE
Minor bug fix in PropertiesUtils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@
 *.so
 .DS_Store
 .settings/**
+.gradle
+lib
+output
+build
+LICENSE.txt.xml
+stanford-corenlp-models-current.jar

--- a/src/edu/stanford/nlp/util/PropertiesUtils.java
+++ b/src/edu/stanford/nlp/util/PropertiesUtils.java
@@ -182,10 +182,10 @@ public class PropertiesUtils {
     for (String keyStr : properties.stringPropertyNames()) {
       if (keyStr.startsWith(prefix)) {
         if (keepPrefix) {
+          ret.setProperty(keyStr, properties.getProperty(keyStr));
+        } else {
           String newStr = keyStr.substring(prefix.length());
           ret.setProperty(newStr, properties.getProperty(keyStr));
-        } else {
-          ret.setProperty(keyStr, properties.getProperty(keyStr));
         }
       }
     }


### PR DESCRIPTION
Incorrect conditional logic was causing prefixes to be removed when keepPrefix was true and kept when it was false.

