### PR TITLE
Convert a small number of stdout / stderr calls to slf4j

### DIFF
--- a/src/edu/stanford/nlp/io/IOUtils.java
+++ b/src/edu/stanford/nlp/io/IOUtils.java
@@ -20,6 +20,9 @@ import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Helper Class for various I/O related things.
  *
@@ -34,6 +37,8 @@ public class IOUtils {
 
   public static final String eolChar = System.getProperty("line.separator");
   public static final String defaultEncoding = "utf-8";
+
+  private static Logger logger = LoggerFactory.getLogger(IOUtils.class);
 
   // A class of static methods
   private IOUtils() { }
@@ -137,7 +142,7 @@ public class IOUtils {
     try {
       return writeObjectToTempFile(o, filename);
     } catch (Exception e) {
-      System.err.println("Error writing object to file " + filename);
+      logger.error("Error writing object to file " + filename);
       e.printStackTrace();
       return null;
     }
@@ -324,7 +329,7 @@ public class IOUtils {
     T obj;
     try {
       Timing timing = new Timing();
-      System.err.print(msg + ' ' + path + " ... ");
+      logger.error(msg + ' ' + path + " ... ");
       obj = IOUtils.readObjectFromURLOrClasspathOrFileSystem(path);
       timing.done();
     } catch (IOException | ClassNotFoundException e) {
@@ -1190,7 +1195,7 @@ public class IOUtils {
       is = uc.getInputStream();
     } catch (SocketTimeoutException e) {
       // e.printStackTrace();
-      System.err.println("Time out. Return empty string");
+      logger.error("Time out. Return empty string");
       return "";
     }
     BufferedReader br = new BufferedReader(new InputStreamReader(is, encoding));
@@ -1381,7 +1386,7 @@ public class IOUtils {
     String[] labels = null;
     List<Map<String,String>> rows = Generics.newArrayList();
     for (String line : IOUtils.readLines(path)) {
-      System.out.println("Splitting "+line);
+      logger.info("Splitting "+line);
       if (labels == null) {
         labels = StringUtils.splitOnCharWithQuoting(line,',','"',escapeChar);
       } else {

--- a/src/edu/stanford/nlp/parser/common/ParserGrammar.java
+++ b/src/edu/stanford/nlp/parser/common/ParserGrammar.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.stanford.nlp.io.IOUtils;
 import edu.stanford.nlp.io.RuntimeIOException;
 import edu.stanford.nlp.ling.CoreLabel;
@@ -39,6 +42,8 @@ import edu.stanford.nlp.parser.lexparser.TreebankLangParserParams;
  * @author John Bauer
  */
 public abstract class ParserGrammar implements Function<List<? extends HasWord>, Tree> {
+
+  private static Logger logger = LoggerFactory.getLogger(ParserGrammar.class);
 
   public abstract ParserQuery parserQuery();
 
@@ -176,7 +181,7 @@ public abstract class ParserGrammar implements Function<List<? extends HasWord>,
     ParserGrammar parser;
     try {
       Timing timing = new Timing();
-      System.err.print("Loading parser from serialized file " + path + " ... ");
+      logger.info("Loading parser from serialized file " + path + " ... ");
       parser = IOUtils.readObjectFromURLOrClasspathOrFileSystem(path);
       timing.done();
     } catch (IOException | ClassNotFoundException e) {

--- a/src/edu/stanford/nlp/parser/lexparser/LexicalizedParser.java
+++ b/src/edu/stanford/nlp/parser/lexparser/LexicalizedParser.java
@@ -62,6 +62,9 @@ import java.util.zip.ZipFile;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * This class provides the top-level API and command-line interface to a set
  * of reasonably good treebank-trained parsers.  The name reflects the main
@@ -88,6 +91,8 @@ import java.lang.reflect.Method;
  * @author John Bauer (made threadsafe)
  */
 public class LexicalizedParser extends ParserGrammar implements Serializable {
+
+  private static Logger logger = LoggerFactory.getLogger(LexicalizedParser.class);
 
   public Lexicon lex;
   public BinaryGrammar bg;
@@ -535,7 +540,7 @@ public class LexicalizedParser extends ParserGrammar implements Serializable {
   protected static LexicalizedParser getParserFromTextFile(String textFileOrUrl, Options op) {
     try {
       Timing tim = new Timing();
-      System.err.print("Loading parser from text file " + textFileOrUrl + ' ');
+      logger.info("Loading parser from text file " + textFileOrUrl + ' ');
       BufferedReader in = IOUtils.readerFromString(textFileOrUrl);
       Timing.startTime();
 
@@ -601,7 +606,7 @@ public class LexicalizedParser extends ParserGrammar implements Serializable {
   public static LexicalizedParser getParserFromSerializedFile(String serializedFileOrUrl) {
     try {
       Timing tim = new Timing();
-      System.err.print("Loading parser from serialized file " + serializedFileOrUrl + " ... ");
+      logger.info("Loading parser from serialized file " + serializedFileOrUrl + " ... ");
       ObjectInputStream in = IOUtils.readStreamFromString(serializedFileOrUrl);
       LexicalizedParser pd = loadModel(in);
 

--- a/src/edu/stanford/nlp/pipeline/StanfordCoreNLP.java
+++ b/src/edu/stanford/nlp/pipeline/StanfordCoreNLP.java
@@ -45,6 +45,9 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static edu.stanford.nlp.util.logging.Redwood.Util.*;
 
 /**
@@ -92,6 +95,8 @@ public class StanfordCoreNLP extends AnnotationPipeline {
   public static final String DEFAULT_NEWLINE_IS_SENTENCE_BREAK = "never";
 
   public static final String DEFAULT_OUTPUT_FORMAT = isXMLOutputPresent() ? "xml" : "text";
+
+  private static Logger logger = LoggerFactory.getLogger(StanfordCoreNLP.class);
 
   /** Formats the constituent parse trees for display */
   private TreePrint constituentTreePrinter;
@@ -178,7 +183,7 @@ public class StanfordCoreNLP extends AnnotationPipeline {
   private static String getRequiredProperty(Properties props, String name) {
     String val = props.getProperty(name);
     if (val == null) {
-      System.err.println("Missing property \"" + name + "\"!");
+      logger.error("Missing property \"" + name + "\"!");
       printRequiredProperties(System.err);
       throw new RuntimeException("Missing property: \"" + name + '\"');
     }
@@ -352,7 +357,7 @@ public class StanfordCoreNLP extends AnnotationPipeline {
     for (String name : annoNames) {
       name = name.trim();
       if (name.isEmpty()) { continue; }
-      System.err.println("Adding annotator " + name);
+      logger.info("Adding annotator " + name);
 
       Annotator an = pool.get(name);
       this.addAnnotator(an);
@@ -435,8 +440,7 @@ public class StanfordCoreNLP extends AnnotationPipeline {
         final String customName =
             property.substring(CUSTOM_ANNOTATOR_PREFIX.length());
         final String customClassName = inputProps.getProperty(property);
-        System.err.println("Registering annotator " + customName +
-            " with class " + customClassName);
+        logger.info("Registering annotator " + customName + " with class " + customClassName);
         pool.register(customName, new AnnotatorFactory(inputProps, annotatorImplementation) {
           private static final long serialVersionUID = 1L;
           @Override
@@ -467,14 +471,15 @@ public class StanfordCoreNLP extends AnnotationPipeline {
 
   public static synchronized Annotator getExistingAnnotator(String name) {
     if(pool == null){
-      System.err.println("ERROR: attempted to fetch annotator \"" + name + "\" before the annotator pool was created!");
+      logger.error("ERROR: attempted to fetch annotator \"" + name + "\" before the annotator pool was created!");
       return null;
     }
     try {
       Annotator a =  pool.get(name);
       return a;
     } catch(IllegalArgumentException e) {
-      System.err.println("ERROR: attempted to fetch annotator \"" + name + "\" but the annotator pool does not store any such type!");
+      logger.error("ERROR: attempted to fetch annotator \"" + name + 
+        "\" but the annotator pool does not store any such type!");
       return null;
     }
   }


### PR DESCRIPTION
[Based on the decision to switch over to slf4j](https://github.com/stanfordnlp/CoreNLP/issues/1#issuecomment-143598156) per @manning , I thought I would put together a small PR to test the slf4j waters with reviewers.

This uses the Logging class (created previously by another contributor) to retrieve an instance of a Logger. If that isn't desired (you'd rather see just ```Logger logger = LoggerFactory.getLogger()```, please let me know and I'll adjust.