### PR TITLE
OpenIE demo needs lemmatization

### DIFF
--- a/src/edu/stanford/nlp/naturalli/OpenIEDemo.java
+++ b/src/edu/stanford/nlp/naturalli/OpenIEDemo.java
@@ -18,7 +18,7 @@ public class OpenIEDemo {
   public static void main(String[] args) throws Exception {
     // Create the Stanford CoreNLP pipeline
     Properties props = new Properties();
-    props.setProperty("annotators", "tokenize,ssplit,pos,depparse,natlog,openie");
+    props.setProperty("annotators", "tokenize,ssplit,pos,depparse,lemma,natlog,openie");
     StanfordCoreNLP pipeline = new StanfordCoreNLP(props);
 
     // Annotate an example document.


### PR DESCRIPTION
Add "lemma" to the set of annotators used in the OpenIE demo. It won't run without it, so it seems like a reasonable change. 