### PR TITLE
Fixes concerning MUC6 and MUC7 coreference resolution input files

### DIFF
--- a/src/edu/stanford/nlp/dcoref/MUCMentionExtractor.java
+++ b/src/edu/stanford/nlp/dcoref/MUCMentionExtractor.java
@@ -93,12 +93,17 @@ public class MUCMentionExtractor extends MentionExtractor {
     Annotation docAnno = new Annotation("");
 
     Pattern docPattern = Pattern.compile("<DOC>(.*?)</DOC>", Pattern.DOTALL+Pattern.CASE_INSENSITIVE);
-    Pattern sentencePattern = Pattern.compile("(<s>|<hl>|<dd>|<DATELINE>)(.*?)(</s>|</hl>|</dd>|</DATELINE>)", Pattern.DOTALL+Pattern.CASE_INSENSITIVE);
+    Pattern sentencePattern = Pattern.compile("(<s>|<hl>|<dd>|<DATELINE>|<p>)(.*?)(</s>|</hl>|</dd>|</DATELINE>|</p>|<p>)", Pattern.DOTALL+Pattern.CASE_INSENSITIVE); // +Pattern.MULTILINE
     Matcher docMatcher = docPattern.matcher(fileContents);
     if (! docMatcher.find(currentOffset)) return null;
 
     currentOffset = docMatcher.end();
     String doc = docMatcher.group(1);
+    // in MUC7 as distributed by LDC,
+    // <p> are not ended with </p>, just a new <p> starts
+    // we handle this here and in the regex above
+    if (doc.endsWith("<p>"))
+      currentOffset -= 3;
     Matcher sentenceMatcher = sentencePattern.matcher(doc);
     String ner = null;
 

--- a/src/edu/stanford/nlp/dcoref/MUCMentionExtractor.java
+++ b/src/edu/stanford/nlp/dcoref/MUCMentionExtractor.java
@@ -93,7 +93,7 @@ public class MUCMentionExtractor extends MentionExtractor {
     Annotation docAnno = new Annotation("");
 
     Pattern docPattern = Pattern.compile("<DOC>(.*?)</DOC>", Pattern.DOTALL+Pattern.CASE_INSENSITIVE);
-    Pattern sentencePattern = Pattern.compile("(<s>|<hl>|<dd>|<DATELINE>|<p>)(.*?)(</s>|</hl>|</dd>|</DATELINE>|</p>|<p>)", Pattern.DOTALL+Pattern.CASE_INSENSITIVE); // +Pattern.MULTILINE
+    Pattern sentencePattern = Pattern.compile("(<s>|<hl>|<dd>|<DATELINE>|<p>)(.*?)(</s>|</hl>|</dd>|</DATELINE>|</p>|<p>)", Pattern.DOTALL+Pattern.CASE_INSENSITIVE);
     Matcher docMatcher = docPattern.matcher(fileContents);
     if (! docMatcher.find(currentOffset)) return null;
 

--- a/src/edu/stanford/nlp/dcoref/MUCMentionExtractor.java
+++ b/src/edu/stanford/nlp/dcoref/MUCMentionExtractor.java
@@ -104,6 +104,9 @@ public class MUCMentionExtractor extends MentionExtractor {
     // we handle this here and in the regex above
     if (doc.endsWith("<p>"))
       currentOffset -= 3;
+    // replace malformed escaped quotes by HTML entities so that tokenizer recognizes tags
+    // (such malformed tokens exist in the MUC6 corpus as distributed by LDC) 
+    doc = doc.replace("\\\"","&quot;");
     Matcher sentenceMatcher = sentencePattern.matcher(doc);
     String ner = null;
 

--- a/src/edu/stanford/nlp/dcoref/MUCMentionExtractor.java
+++ b/src/edu/stanford/nlp/dcoref/MUCMentionExtractor.java
@@ -240,6 +240,12 @@ public class MUCMentionExtractor extends MentionExtractor {
     Map<Integer, Mention> idMention = Generics.newHashMap();    // temporary use
     for (List<Mention> goldMentions : allGoldMentions) {
       for (Mention m : goldMentions) {
+        if (idMention.containsKey(m.mentionID) && !idMention.containsKey(m.originalRef)) {
+          // use reverse (some annotations in MUC6 as distributed by LDC contain swapped IDs (REF and ID is swapped))
+          Integer tmp = m.mentionID;
+          m.mentionID = m.originalRef;
+          m.originalRef = tmp;
+        }
         idMention.put(m.mentionID, m);
       }
     }

--- a/src/edu/stanford/nlp/dcoref/MUCMentionExtractor.java
+++ b/src/edu/stanford/nlp/dcoref/MUCMentionExtractor.java
@@ -249,6 +249,15 @@ public class MUCMentionExtractor extends MentionExtractor {
         idMention.put(m.mentionID, m);
       }
     }
+    // check if all originalRef pointers point to existing mentions
+    // (in MUC7 as distributed by LDC there are some that point to non-existing mentions, causing problems in dcoref)
+    for (List<Mention> goldMentions : allGoldMentions) {
+      for (Mention m : goldMentions) {
+        if (!idMention.containsKey(m.originalRef))
+          // delete ref to non-existing mention
+          m.originalRef = -1;
+      }
+    }
     for (List<Mention> goldMentions : allGoldMentions) {
       for (Mention m : goldMentions) {
         if (m.goldCorefClusterID == -1) {

--- a/src/edu/stanford/nlp/dcoref/MentionExtractor.java
+++ b/src/edu/stanford/nlp/dcoref/MentionExtractor.java
@@ -247,6 +247,10 @@ public class MentionExtractor {
   public static void mergeLabels(Tree tree, List<CoreLabel> sentence) {
     int idx = 0;
     for (Tree t : tree.getLeaves()) {
+      if (idx >= sentence.size()) {
+        System.err.printf("warning: could not assing CoreLabel to tree leaf %s (skipping)", t.value());
+        continue;
+      }
       CoreLabel cl = sentence.get(idx ++);
       String value = t.value();
       cl.set(CoreAnnotations.ValueAnnotation.class, value);


### PR DESCRIPTION
These changes make it possible to use dcoref with MUC6 and MUC7 files for coreference resolution as distributed by LDC. The existing code had problems with both files.

(I declare that this contribution is in the public domain.)
