### PR TITLE
Chinese coreference resolution API example

### DIFF
--- a/itest/src/edu/stanford/nlp/hcoref/HcorefChineseAPIExampleTest.java
+++ b/itest/src/edu/stanford/nlp/hcoref/HcorefChineseAPIExampleTest.java
@@ -1,0 +1,56 @@
+package edu.stanford.nlp.hcoref;
+
+import edu.stanford.nlp.hcoref.CorefCoreAnnotations;
+import edu.stanford.nlp.hcoref.data.CorefChain;
+import edu.stanford.nlp.hcoref.data.Mention;
+import edu.stanford.nlp.ling.CoreAnnotations;
+import edu.stanford.nlp.pipeline.Annotation;
+import edu.stanford.nlp.pipeline.StanfordCoreNLP;
+import edu.stanford.nlp.util.CoreMap;
+import edu.stanford.nlp.util.StringUtils;
+
+import java.util.Properties;
+
+/**
+ * A simple example of Stanford Chinese coreference resolution
+ * 
+ * When I use originAPI code, using the properties file in path edu/stanford/nlp/hcoref/properties/zh-dcoref-default.properties
+ * the code could not run correctly in Chinese. 
+ * 
+ * What I did is extracting the right properties file from stanford-chinese-corenlp-2015-12-08-models.jar
+ * and replace edu/stanford/nlp/hcoref/properties/zh-coref-default.properties to our originAPI code 
+ * which finally run correctly.
+ * 
+ * @originAPI http://stanfordnlp.github.io/CoreNLP/coref.html 
+ * @modify_author zkli
+ */
+public class CorefExample {
+	public static void main(String[] args) throws Exception {
+		long startTime=System.currentTimeMillis();
+		
+		String text = "小明吃了个冰棍，他很开心。";
+		args = new String[] {"-props", "edu/stanford/nlp/hcoref/properties/zh-coref-default.properties" };
+
+		Annotation document = new Annotation(text);
+		Properties props = StringUtils.argsToProperties(args);
+		StanfordCoreNLP pipeline = new StanfordCoreNLP(props);
+		pipeline.annotate(document);
+		System.out.println("---");
+		System.out.println("coref chains");
+		
+		for (CorefChain cc : document.get(CorefCoreAnnotations.CorefChainAnnotation.class).values()) {
+			System.out.println("\t" + cc);
+		}
+		for (CoreMap sentence : document.get(CoreAnnotations.SentencesAnnotation.class)) {
+			System.out.println("---");
+			System.out.println("mentions");
+			for (Mention m : sentence.get(CorefCoreAnnotations.CorefMentionsAnnotation.class)) {
+				System.out.println("\t" + m);
+			}
+		}
+		
+		long endTime=System.currentTimeMillis(); 
+		long time = (endTime-startTime)/1000;
+		System.out.println("Running time "+time/60+"min "+time%60+"s");
+	}
+}

--- a/itest/src/edu/stanford/nlp/hcoref/HcorefChineseAPIExampleTest.java
+++ b/itest/src/edu/stanford/nlp/hcoref/HcorefChineseAPIExampleTest.java
@@ -24,7 +24,7 @@ import java.util.Properties;
  * @originAPI http://stanfordnlp.github.io/CoreNLP/coref.html 
  * @modify_author zkli
  */
-public class CorefExample {
+public class HcorefChineseAPIExampleTest {
 	public static void main(String[] args) throws Exception {
 		long startTime=System.currentTimeMillis();
 		

--- a/src/edu/stanford/nlp/hcoref/properties/zh-coref-default.properties
+++ b/src/edu/stanford/nlp/hcoref/properties/zh-coref-default.properties
@@ -1,0 +1,41 @@
+# Pipeline options
+annotators = segment, ssplit, pos, lemma, ner, parse, mention, coref
+
+coref.sieves = ChineseHeadMatch, ExactStringMatch, PreciseConstructs, StrictHeadMatch1, StrictHeadMatch2, StrictHeadMatch3, StrictHeadMatch4, PronounMatch
+coref.input.type = raw
+coref.postprocessing = true
+coref.calculateFeatureImportance = false
+coref.useConstituencyTree = true
+#coref.useConstituencyTree = false
+coref.useSemantics = false
+coref.md.type = RULE
+coref.mode = hybrid
+
+coref.path.word2vec =
+coref.language = zh
+coref.print.md.log = false
+coref.defaultPronounAgreement = true
+coref.big.gender.number = edu/stanford/nlp/models/dcoref/gender.data.gz
+coref.zh.dict = edu/stanford/nlp/models/dcoref/zh-attributes.txt.gz
+
+# NER
+ner.model = edu/stanford/nlp/models/ner/chinese.misc.distsim.crf.ser.gz
+ner.applyNumericClassifiers = false
+ner.useSUTime = false
+
+# segment
+customAnnotatorClass.segment = edu.stanford.nlp.pipeline.ChineseSegmenterAnnotator
+
+segment.model = edu/stanford/nlp/models/segmenter/chinese/ctb.gz
+segment.sighanCorporaDict = edu/stanford/nlp/models/segmenter/chinese
+segment.serDictionary = edu/stanford/nlp/models/segmenter/chinese/dict-chris6.ser.gz
+segment.sighanPostProcessing = true
+
+# sentence split
+ssplit.boundaryTokenRegex = [.]|[!?]+|[。]|[！？]+
+
+#pos
+pos.model = edu/stanford/nlp/models/pos-tagger/chinese-distsim/chinese-distsim.tagger
+
+#parse
+parse.model = edu/stanford/nlp/models/lexparser/chinesePCFG.ser.gz


### PR DESCRIPTION
Because the API code in http://stanfordnlp.github.io/CoreNLP/coref.html
and http://nlp.stanford.edu/software/dcoref.shtml are not runable under
Chinese text instances test, I modified the properties file, which is
extracted from stanford-chinese-corenlp-2015-12-08-models.jar file.
Finally our code is successfully run under Chinese.

============================
1) ADD properties file under edu/stanford/nlp/hcoref/properties/zh-coref-default.properties

2) ADD java file under itest/src/edu/stanford/nlp/hcoref/HcorefChineseAPIExampleTest.java