### PR TITLE
nndep Classifier and Config: Prevent fine-tuning with flag.

### DIFF
--- a/src/edu/stanford/nlp/parser/nndep/Classifier.java
+++ b/src/edu/stanford/nlp/parser/nndep/Classifier.java
@@ -1,4 +1,4 @@
-package edu.stanford.nlp.parser.nndep; 
+package edu.stanford.nlp.parser.nndep;
 import edu.stanford.nlp.util.logging.Redwood;
 
 import edu.stanford.nlp.util.CollectionUtils;
@@ -592,10 +592,12 @@ public class Classifier  {
       }
     }
 
-    for (int i = 0; i < E.length; ++i) {
-      for (int j = 0; j < E[i].length; ++j) {
-        eg2E[i][j] += gradE[i][j] * gradE[i][j];
-        E[i][j] -= adaAlpha * gradE[i][j] / Math.sqrt(eg2E[i][j] + adaEps);
+    if (config.doWordEmbeddingGradUpdate) {
+      for (int i = 0; i < E.length; ++i) {
+        for (int j = 0; j < E[i].length; ++j) {
+          eg2E[i][j] += gradE[i][j] * gradE[i][j];
+          E[i][j] -= adaAlpha * gradE[i][j] / Math.sqrt(eg2E[i][j] + adaEps);
+        }
       }
     }
   }

--- a/src/edu/stanford/nlp/parser/nndep/Config.java
+++ b/src/edu/stanford/nlp/parser/nndep/Config.java
@@ -1,4 +1,4 @@
-package edu.stanford.nlp.parser.nndep; 
+package edu.stanford.nlp.parser.nndep;
 import edu.stanford.nlp.util.logging.Redwood;
 
 import edu.stanford.nlp.international.Language;
@@ -170,7 +170,13 @@ public class Config
   */
   public boolean noPunc = true;
 
-  /** 
+  /**
+  *  Update word embeddings when performing gradient descent.
+  *  Set to false if you provide embeddings and do not want to finetune.
+  */
+  public boolean doWordEmbeddingGradUpdate = true;
+
+  /**
    * Describes language-specific properties necessary for training and
    * testing. By default,
    * {@link edu.stanford.nlp.trees.PennTreebankLanguagePack} will be
@@ -226,6 +232,7 @@ public class Config
     unlabeled = PropertiesUtils.getBool(props, "unlabeled", unlabeled);
     cPOS = PropertiesUtils.getBool(props, "cPOS", cPOS);
     noPunc = PropertiesUtils.getBool(props, "noPunc", noPunc);
+    doWordEmbeddingGradUpdate = PropertiesUtils.getBool(props, "doWordEmbeddingGradUpdate", doWordEmbeddingGradUpdate);
 
     // Runtime parsing options
     sentenceDelimiter = PropertiesUtils.getString(props, "sentenceDelimiter", sentenceDelimiter);
@@ -276,5 +283,6 @@ public class Config
     System.err.printf("unlabeled = %b%n", unlabeled);
     System.err.printf("cPOS = %b%n", cPOS);
     System.err.printf("noPunc = %b%n", noPunc);
+    System.err.printf("doWordEmbeddingGradUpdate = %b%n", doWordEmbeddingGradUpdate);
   }
 }


### PR DESCRIPTION
Add a flag (default: true) for performing the word embedding gradient update. The main purpose is for those who want to provide their own embeddings and not fine-tune them.