### PR TITLE
Fixed not to call APIs to corenlp.run, but localhost in the web UI

### DIFF
--- a/src/edu/stanford/nlp/pipeline/demo/corenlp-brat.js
+++ b/src/edu/stanford/nlp/pipeline/demo/corenlp-brat.js
@@ -2,7 +2,8 @@
 // and uses brat to render everything.
 
 //var serverAddress = 'http://localhost:9000/'
-var serverAddress = 'http://corenlp.run'
+//var serverAddress = 'http://corenlp.run'
+var serverAddress = ''
 
 // Load Brat libraries
 var bratLocation = 'https://storage.googleapis.com/corenlp/js/brat';


### PR DESCRIPTION
The current version calls APIs to http://corenlp.run, which is not ideal when you run your own server and want to test it using the web user interface.