### PR TITLE
Add stackedNer key to AnnotationLookup to allow hybrid NER training

### DIFF
--- a/src/edu/stanford/nlp/ling/AnnotationLookup.java
+++ b/src/edu/stanford/nlp/ling/AnnotationLookup.java
@@ -70,6 +70,7 @@ public class AnnotationLookup {
     SECTION_KEY(CoreAnnotations.SectionAnnotation.class,"section"),
     SECTIONID_KEY(CoreAnnotations.SectionIDAnnotation.class,"sectionID"),
     SECTIONDATE_KEY(CoreAnnotations.SectionDateAnnotation.class,"sectionDate"),
+    STACKED_NER_KEY(CoreAnnotations.StackedNamedEntityTagAnnotation.class, "stackedNer"),
 
     // Thang Sep13: for Genia NER
     HEAD_KEY(CoreAnnotations.HeadWordStringAnnotation.class, "head"),


### PR DESCRIPTION
This additional key allows for adding a stackedNer to a properties map for CRFClassifier:
`properties.put("map", "word=0,stackedNer=1,tag=2,lemma=3,answer=4");`
So stackedNer feature in CRFClassifier can be fully used for training statistical model.

I hereby declare this one line of code public domain or whatever license you need.