### PR TITLE
Enabled partitionTrain in MachineReading

### DIFF
--- a/src/edu/stanford/nlp/ie/machinereading/MachineReading.java
+++ b/src/edu/stanford/nlp/ie/machinereading/MachineReading.java
@@ -706,7 +706,9 @@ public class MachineReading  {
 				}
         
         // for learning curve experiments
-        // partitionTrain = keepPercentage(partitionTrain, percentageOfTrain);        
+        // partitionTrain = keepPercentage(partitionTrain, percentageOfTrain);   
+        partitionTrain = keepPercentage(partitionTrain, MachineReadingProperties.percentageOfTrain);        
+        
         
 				if (auxDataset != null) {
 					for (int ind = 0; ind < AnnotationUtils.sentenceCount(auxDataset); ind++) {


### PR DESCRIPTION
Enabled partitionTrain in MachineReading, which was hashedout