### PR TITLE
Switches default truecase model to model from default distribution

### DIFF
--- a/src/edu/stanford/nlp/pipeline/DefaultPaths.java
+++ b/src/edu/stanford/nlp/pipeline/DefaultPaths.java
@@ -24,7 +24,7 @@ public class DefaultPaths {
   public static final String DEFAULT_REGEXNER_RULES = "edu/stanford/nlp/models/regexner/type_map_clean";
   public static final String DEFAULT_GENDER_FIRST_NAMES = "edu/stanford/nlp/models/gender/first_name_map_small";
 
-    public static final String DEFAULT_TRUECASE_MODEL = "edu/stanford/nlp/models/truecase/truecasing.fast.qn.ser.gz";
+  public static final String DEFAULT_TRUECASE_MODEL = "edu/stanford/nlp/models/truecase/truecasing.fast.qn.ser.gz";
   public static final String DEFAULT_TRUECASE_DISAMBIGUATION_LIST = "edu/stanford/nlp/models/truecase/MixDisambiguation.list";
 
   public static final String DEFAULT_DCOREF_ANIMATE = "edu/stanford/nlp/models/dcoref/animate.unigrams.txt";

--- a/src/edu/stanford/nlp/pipeline/DefaultPaths.java
+++ b/src/edu/stanford/nlp/pipeline/DefaultPaths.java
@@ -24,7 +24,7 @@ public class DefaultPaths {
   public static final String DEFAULT_REGEXNER_RULES = "edu/stanford/nlp/models/regexner/type_map_clean";
   public static final String DEFAULT_GENDER_FIRST_NAMES = "edu/stanford/nlp/models/gender/first_name_map_small";
 
-  public static final String DEFAULT_TRUECASE_MODEL = "edu/stanford/nlp/models/truecase/truecasing.fast.caseless.qn.ser.gz";
+    public static final String DEFAULT_TRUECASE_MODEL = "edu/stanford/nlp/models/truecase/truecasing.fast.qn.ser.gz";
   public static final String DEFAULT_TRUECASE_DISAMBIGUATION_LIST = "edu/stanford/nlp/models/truecase/MixDisambiguation.list";
 
   public static final String DEFAULT_DCOREF_ANIMATE = "edu/stanford/nlp/models/dcoref/animate.unigrams.txt";


### PR DESCRIPTION
The model "truecasing.fast.caseless.qn.ser.gz" is set as the default for the truecase annotator, but this model isn't included in the default CoreNLP distribution (http://stackoverflow.com/questions/35574874/core-nlp-truecaseannotator-not-found). This changes the default model to "truecasing.fast.qn.ser.gz", which is included.