### PR TITLE
batch endTree index bug fix

### DIFF
--- a/src/edu/stanford/nlp/sentiment/SentimentTraining.java
+++ b/src/edu/stanford/nlp/sentiment/SentimentTraining.java
@@ -76,7 +76,7 @@ public class SentimentTraining  {
         // the list
         int startTree = batch * model.op.trainOptions.batchSize;
         int endTree = (batch + 1) * model.op.trainOptions.batchSize;
-        if (endTree + model.op.trainOptions.batchSize > shuffledSentences.size()) {
+        if (endTree > shuffledSentences.size()) {
           endTree = shuffledSentences.size();
         }
 


### PR DESCRIPTION
I think the original code meant to have `(startTree + batchSize > shuffledSentences.size())` as the if condition, but instead had `(endTree + ...)`. This may make the second to last batch to have a wrong `endTree` index, thus including the data from the last batch, and these data would be used twice.