### PR TITLE
Use correct CoNLL-X POS field

### DIFF
--- a/src/edu/stanford/nlp/trees/GrammaticalStructure.java
+++ b/src/edu/stanford/nlp/trees/GrammaticalStructure.java
@@ -1060,7 +1060,7 @@ public abstract class GrammaticalStructure implements Serializable  {
   // Note that these field constants are 0-based whereas much documentation is 1-based
 
   public static final int CoNLLX_WordField = 1;
-  public static final int CoNLLX_POSField = 3;
+  public static final int CoNLLX_POSField = 4;
   public static final int CoNLLX_GovField = 6;
   public static final int CoNLLX_RelnField = 7;
 


### PR DESCRIPTION
According to the [CoNLL-X spec](http://ilk.uvt.nl/conll/), the POS is in the fourth field whereas the coarse-grained POS is in the third, which what is currently extracted.

This PR is also consistent with [parser.nndep.Util.loadConllFile](https://github.com/stanfordnlp/CoreNLP/blob/master/src/edu/stanford/nlp/parser/nndep/Util.java#L145) which defaults to using the fine-grained POS.

Since the POS is equivalent to the CPOS when unavailable, this change should provide more utility to downstream applications without introducing many backward incompatibilities.