### PR TITLE
Correct example of IOB1 vs IOB2

### DIFF
--- a/src/edu/stanford/nlp/pipeline/LabeledChunkIdentifier.java
+++ b/src/edu/stanford/nlp/pipeline/LabeledChunkIdentifier.java
@@ -18,8 +18,8 @@ import java.util.regex.Pattern;
  * The type is
  * Example:  Bill   works for  Bank   of     America
  * IO:       I-PER  O     O    I-ORG  I-ORG  I-ORG
- * IOB1:     B-PER  O     O    B-ORG  I-ORG  I-ORG
- * IOB2:     I-PER  O     O    B-ORG  I-ORG  I-ORG
+ * IOB1:     I-PER  O     O    I-ORG  I-ORG  I-ORG
+ * IOB2:     B-PER  O     O    B-ORG  I-ORG  I-ORG
  * IOE1:     E-PER  O     O    I-ORG  I-ORG  E-ORG
  * IOE2:     I-PER  O     O    I-ORG  I-ORG  E-ORG
  * BILOU:    U-PER  O     O    B-ORG  I-ORG  L-ORG


### PR DESCRIPTION
It seems that the examples of IOB1 and IOB2 tagging are wrong (according to the definition from http://cs229.stanford.edu/proj2005/KrishnanGanapathy-NamedEntityRecognition.pdf for instance).