### PR TITLE
Remove Google Analytics code from local Server demo installations.

### DIFF
--- a/src/edu/stanford/nlp/pipeline/demo/corenlp-brat.html
+++ b/src/edu/stanford/nlp/pipeline/demo/corenlp-brat.html
@@ -15,16 +15,6 @@
   <link rel="stylesheet" type="text/css" href="corenlp-brat.css"/>
   <script type="text/javascript" src="corenlp-brat.js"></script>
 
-  <!-- Google Analytics -->
-  <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-28753732-2', 'auto');
-  ga('send', 'pageview');
-  </script>
-
   <meta charset="UTF-8">
 </head>
 


### PR DESCRIPTION
CoreNLP Server demo includes Google Analytics code.  It uses the Google Analytics ID of http://corenlp.run/. This is presumably an error.

This patch removes GA code from the template.