### PR TITLE
Fix NPE for ColumnDataClassifier initialization from model (enableassertions case)

### DIFF
--- a/src/edu/stanford/nlp/classify/ColumnDataClassifier.java
+++ b/src/edu/stanford/nlp/classify/ColumnDataClassifier.java
@@ -1588,7 +1588,7 @@ public class ColumnDataClassifier  {
         ois = IOUtils.readStreamFromString(loadPath);
         classifier = ErasureUtils.<LinearClassifier<String,String>>uncheckedCast(ois.readObject());
         myFlags = (Flags[]) ois.readObject();
-        assert flags.length > 0;
+        assert myFlags.length > 0;
         logger.info("Done.");
       } catch (Exception e) {
         throw new RuntimeIOException("Error deserializing " + loadPath, e);


### PR DESCRIPTION
`flags` here always null. Problem is reproduced with `-enableassertions` java oprion