### PR TITLE
add missing WEEKDAY variable

### DIFF
--- a/src/edu/stanford/nlp/time/rules/defs.sutime.txt
+++ b/src/edu/stanford/nlp/time/rules/defs.sutime.txt
@@ -55,6 +55,12 @@
   SATURDAY = DayOfWeek(6);
   SUNDAY = DayOfWeek(7);
 
+  WEEKDAY = {
+    type: DAYS_OF_WEEK,
+    label: "WD",
+    value: TimeWithRange(TimeRange(MONDAY, FRIDAY, Duration(DAY, 5)))
+  }
+
   WEEKEND = {
     type: DAYS_OF_WEEK,
     label: "WE",


### PR DESCRIPTION
SUTime used the variable "WEEKDAY" in some expressions, but it never 
defined that expression. This resulted in the somewhat frequent warning
Unknown variable: WEEKDAY. Note that the Timex2 standard does not 
have a weekday symbol (though it has a weekend symbol), and my choice
of "WD" is not standard (though it seems like an obvious choice).
