### PR TITLE
Server: customize NER model path

### DIFF
--- a/src/edu/stanford/nlp/pipeline/StanfordCoreNLPServer.java
+++ b/src/edu/stanford/nlp/pipeline/StanfordCoreNLPServer.java
@@ -69,6 +69,7 @@ public class StanfordCoreNLPServer implements Runnable {
   protected static String defaultAnnotators = "tokenize,ssplit,pos,lemma,ner,parse,depparse,mention,coref,natlog,openie,regexner,kbp";
   @ArgumentParser.Option(name="preload", gloss="Cache the following annotators on startup")
   protected static String preloadedAnnotators = "";
+  protected static String[] runtimeProps = { "ner.model" };// these system properties at runtime
 
   protected final String shutdownKey;
 
@@ -121,6 +122,11 @@ public class StanfordCoreNLPServer implements Runnable {
         "parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz",  // SR scales linearly with sentence length. Good for a server!
         "parse.binaryTrees", "true",  // needed for the Sentiment annotator
         "openie.strip_entailments", "true");  // these are large to serialize, so ignore them
+    for (String prop : runtimeProps) { //add or override properties at runtime
+      if (System.getProperty(prop) != null) {
+        this.defaultProps.setProperty(prop, System.getProperty(prop));
+      }
+    }
     this.serverExecutor = Executors.newFixedThreadPool(ArgumentParser.threads);
     this.corenlpExecutor = Executors.newFixedThreadPool(ArgumentParser.threads);
 


### PR DESCRIPTION
I wasn't able to set custom ner.model path to the Server, so I modified few lines of code to get it working.

we can now set `-Dner.model` system property at runtime.

```
java -cp .:* \ 
 -Dner.model="ner-model.ser.gz,edu/stanford/nlp/models/ner/english.all.3class.distsim.crf.ser.gz"  \ 
edu.stanford.nlp.pipeline.StanfordCoreNLPServer
```

This is a minor change involving 6 additions. 
