### PR TITLE
StringUtils.decodeArray un-escaping fix

### DIFF
--- a/src/edu/stanford/nlp/pipeline/TokensRegexAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/TokensRegexAnnotator.java
@@ -63,8 +63,8 @@ public class TokensRegexAnnotator implements Annotator {
 
   public TokensRegexAnnotator(String name, Properties props) {
     String prefix = (name == null)? "": name + '.';
-    List<String> files  = StringUtils.split(props.getProperty(prefix + "rules"), "\\s*[,;]\\s*");
-    if (files.isEmpty()) {
+    String[] files  = PropertiesUtils.getStringArray(props, prefix + "rules");
+    if (files == null || files.length == 0) {
       throw new RuntimeException("No rules specified for TokensRegexAnnotator " + name + ", check " + prefix + "rules property");
     }
     env = TokenSequencePattern.getNewEnv();

--- a/src/edu/stanford/nlp/pipeline/TokensRegexAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/TokensRegexAnnotator.java
@@ -63,8 +63,8 @@ public class TokensRegexAnnotator implements Annotator {
 
   public TokensRegexAnnotator(String name, Properties props) {
     String prefix = (name == null)? "": name + '.';
-    String[] files  = StringUtils.split(props.getProperty(prefix + "rules"), "\\s*[,;]\\s*")
-    if (files == null || files.length == 0) {
+    List<String> files  = StringUtils.split(props.getProperty(prefix + "rules"), "\\s*[,;]\\s*");
+    if (files.isEmpty()) {
       throw new RuntimeException("No rules specified for TokensRegexAnnotator " + name + ", check " + prefix + "rules property");
     }
     env = TokenSequencePattern.getNewEnv();

--- a/src/edu/stanford/nlp/util/StringUtils.java
+++ b/src/edu/stanford/nlp/util/StringUtils.java
@@ -2501,11 +2501,6 @@ public class StringUtils  {
       if (chars[i] == '\r') {
         // Ignore funny windows carriage return
         continue;
-      } else if(chars[i] == '\\'){
-        //(case: escaped character)
-        if(i == chars.length - 1) throw new IllegalArgumentException("Last character of encoded array is escape character: " + encoded);
-        current.append(chars[i+1]);
-        i += 1;
       } else if (quoteCloseChar != 0) {
         //(case: in quotes)
         if(chars[i] == quoteCloseChar){
@@ -2513,6 +2508,11 @@ public class StringUtils  {
         }else{
           current.append(chars[i]);
         }
+      } else if(chars[i] == '\\'){
+        //(case: escaped character)
+        if(i == chars.length - 1) throw new IllegalArgumentException("Last character of encoded array is escape character: " + encoded);
+        current.append(chars[i+1]);
+        i += 1;
       } else {
         //(case: normal)
         if(chars[i] == '"'){

--- a/test/src/edu/stanford/nlp/util/MetaClassTest.java
+++ b/test/src/edu/stanford/nlp/util/MetaClassTest.java
@@ -1,8 +1,10 @@
 package edu.stanford.nlp.util;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -395,6 +397,20 @@ public class MetaClassTest {
 
     Integer[] intsEmpty = MetaClass.cast("", Integer[].class);
     assertArrayEquals(new Integer[]{}, intsEmpty);
+  }
+
+  @Test
+  public void testCastStringArray() throws IOException {
+    String[] strings1 = MetaClass.cast("[a,b,c]", String[].class);
+    assertArrayEquals(new String[]{"a", "b", "c"}, strings1);
+
+    String string1 = Files.createTempFile("TestCastString", "tmp").toString();
+    String string2 = Files.createTempFile("TestCastString", "tmp").toString();
+    String[] strings2 = MetaClass.cast("['" + string1 + "','" + string2 + "']", String[].class);
+    assertArrayEquals(new String[]{string1, string2}, strings2);
+
+    String[] strings3 = MetaClass.cast("['a','b','c']", String[].class);
+    assertArrayEquals(new String[]{"a", "b", "c"}, strings3);
   }
 
   private static enum Fruits {

--- a/test/src/edu/stanford/nlp/util/StringUtilsTest.java
+++ b/test/src/edu/stanford/nlp/util/StringUtilsTest.java
@@ -2,6 +2,8 @@ package edu.stanford.nlp.util;
 
 import junit.framework.TestCase;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.*;
 
 public class StringUtilsTest extends TestCase {
@@ -216,6 +218,16 @@ public class StringUtilsTest extends TestCase {
     assertEquals("xxx [out_A] xxx", StringUtils.expandEnvironmentVariables("xxx $_A xxx", env));
     assertEquals("xxx $3A xxx", StringUtils.expandEnvironmentVariables("xxx $3A xxx", env));
     assertEquals("xxx  xxx", StringUtils.expandEnvironmentVariables("xxx $UNDEFINED xxx", env));
+  }
+
+  public void testDecodeArray() throws IOException {
+    String tempFile1 = Files.createTempFile("test", "tmp").toString();
+    String tempFile2 = Files.createTempFile("test", "tmp").toString();
+    String[] decodedArray = StringUtils.decodeArray("'"+tempFile1 + "','" + tempFile2+"'");
+
+    assertEquals(2, decodedArray.length);
+    assertEquals(tempFile1, decodedArray[0]);
+    assertEquals(tempFile2, decodedArray[1]);
   }
 
 }


### PR DESCRIPTION
Fix for #311.

StringUtils.decodeArray now does not try to un-escape characters inside quotes. Test cases are included to demonstrate behaviour that has been fixed.

(This contribution is in the public domain)