### PR TITLE
Fix jarfile dependency issue for Makefile compilation

### DIFF
--- a/doc/corenlp/Makefile
+++ b/doc/corenlp/Makefile
@@ -2,7 +2,7 @@
 # We actually use ant (q.v.) or a Java IDE.
 
 JAVAC = javac
-JAVAFLAGS = -O -d classes -encoding utf-8
+JAVAFLAGS = -O -d classes -encoding utf-8 -cp "*"
 
 # Builds the classes' jar file
 corenlp: source


### PR DESCRIPTION
Jar dependencies aren't properly included in the corenlp target, causing a bunch of missing imports compiler errors.