### PR TITLE
Use WARN level for obvious warning log.

### DIFF
--- a/src/edu/stanford/nlp/pipeline/POSTaggerAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/POSTaggerAnnotator.java
@@ -134,7 +134,8 @@ public class POSTaggerAnnotator implements Annotator  {
       try {
         tagged = pos.tagSentence(tokens, this.reuseTags);
       } catch (OutOfMemoryError e) {
-        log.info("WARNING: Tagging of sentence ran out of memory. " +
+        log.error(e); // Beware that we can now get an OOM in logging, too.
+        log.warn("Tagging of sentence ran out of memory. " +
                            "Will ignore and continue: " +
                            SentenceUtils.listToString(tokens));
       }

--- a/src/edu/stanford/nlp/pipeline/ParserAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/ParserAnnotator.java
@@ -338,7 +338,7 @@ public class ParserAnnotator extends SentenceAnnotator  {
       } else {
         List<ScoredObject<Tree>> scoredObjects = pq.getKBestParses(this.kBest);
         if (scoredObjects == null || scoredObjects.size() < 1) {
-          log.info("WARNING: Parsing of sentence failed.  " +
+          log.warn("Parsing of sentence failed.  " +
               "Will ignore and continue: " +
               SentenceUtils.listToString(words));
         } else {
@@ -351,11 +351,11 @@ public class ParserAnnotator extends SentenceAnnotator  {
         }
       }
     } catch (OutOfMemoryError e) {
-      Runtime.getRuntime().gc();
-      log.info("WARNING: Parsing of sentence ran out of memory (length=" + words.size() + ").  " +
-              "Will ignore and continue.");
+      log.error(e); // Beware that we can now get an OOM in logging, too.
+      log.warn("Parsing of sentence ran out of memory (length=" + words.size() + ").  " +
+              "Will ignore and try to continue.");
     } catch (NoSuchParseException e) {
-      log.info("WARNING: Parsing of sentence failed, possibly because of out of memory.  " +
+      log.warn("Parsing of sentence failed, possibly because of out of memory.  " +
               "Will ignore and continue: " +
               SentenceUtils.listToString(words));
     }


### PR DESCRIPTION
But currently the actual OOM backtrace is, unfortunately, lost.
Redwood logging does not appear to allow logging of error traces?