### PR TITLE
Update Neural CorefSystem to retain singletons

### DIFF
--- a/src/edu/stanford/nlp/coref/CorefSystem.java
+++ b/src/edu/stanford/nlp/coref/CorefSystem.java
@@ -90,8 +90,9 @@ public class CorefSystem {
           Redwood.log(getName(), "Coref took "
               + (System.currentTimeMillis() - time) / 1000.0 + "s");
         }
-        CorefUtils.removeSingletonClusters(document);
-        writerAfterCoref.print(CorefPrinter.printConllOutput(document, false, true));
+        if(removeSingletonClusters)
+        	CorefUtils.removeSingletonClusters(document);
+        writerAfterCoref.print(CorefPrinter.printConllOutput(document, false, removeSingletonClusters));
       }
 
       @Override


### PR DESCRIPTION
After the change, the *.coref.predicted.txt will retain singleton mentions. Or else, they will be filtered out regardless of the variable "removeSingletonClusters".