### PR TITLE
Make JSONWriter constructor public

### DIFF
--- a/src/edu/stanford/nlp/pipeline/JSONOutputter.java
+++ b/src/edu/stanford/nlp/pipeline/JSONOutputter.java
@@ -262,7 +262,7 @@ public class JSONOutputter extends AnnotationOutputter {
 
     });
 
-    l0.writer.flush();  // flush
+    l0.flush();  // flush
   }
 
   /**
@@ -494,6 +494,10 @@ public class JSONOutputter extends AnnotationOutputter {
           writer.write(INDENT_CHAR);
         }
       }
+    }
+
+    public void flush() {
+      writer.flush();
     }
 
     private void space() {

--- a/src/edu/stanford/nlp/pipeline/JSONOutputter.java
+++ b/src/edu/stanford/nlp/pipeline/JSONOutputter.java
@@ -323,7 +323,7 @@ public class JSONOutputter extends AnnotationOutputter {
   public static class JSONWriter {
     private final PrintWriter writer;
     private final Options options;
-    private JSONWriter(PrintWriter writer, Options options) {
+    public JSONWriter(PrintWriter writer, Options options) {
       this.writer = writer;
       this.options = options;
     }


### PR DESCRIPTION
JSONWriter is a public class but its constructor is currently
private. This renders it completely unuseable for any practical
purpose outside of JSONOutputter and JSONOutputter's test.

This makes its constructor public. This allows it to be used in cases
where e.g. the JSONOutputter is subclassed.