### PR TITLE
Support passing parameters on page launch, via window.location.hash

### DIFF
--- a/src/edu/stanford/nlp/pipeline/demo/corenlp-brat.js
+++ b/src/edu/stanford/nlp/pipeline/demo/corenlp-brat.js
@@ -1066,6 +1066,41 @@ $(document).ready(function() {
     return false;
   });
 
+  // Support passing parameters on page launch, via window.location.hash parameters.
+  // Example: http://localhost:9000/#text=foo%20bar&annotators=pos,lemma,ner
+  (function() {
+    var rawParams = window.location.hash.slice(1).split("&");
+    var params = {};
+    rawParams.forEach(function(paramKV) {
+      paramKV = paramKV.split("=");
+      if (paramKV.length === 2) {
+        var key   = paramKV[0];
+        var value = paramKV[1];
+        params[key] = value;
+      }
+    });
+    if (params.text) {
+      var text = decodeURIComponent(params.text);
+      $('#text').val(text);
+    }
+    if (params.annotators) {
+      var annotators = params.annotators.split(",");
+      // De-select everything
+      $('#annotators').find('option').each(function() {
+        $(this).prop('selected', false);
+      });
+      // Select the specified ones.
+      annotators.forEach(function(a) {
+        $('#annotators').find('option[value="'+a+'"]').prop('selected', true);
+      });
+      // Refresh Chosen
+      $('#annotators').trigger('chosen:updated');
+    }
+    if (params.text || params.annotators) {
+      // Finally, let's auto-submit.
+      $('#submit').click();
+    }
+  })();
 
   $('#form_tokensregex').submit( function (e) {
     // Don't actually submit the form


### PR DESCRIPTION
The need for this was briefly discussed on [Stack Overflow](http://stackoverflow.com/questions/43663335/use-get-params-to-provide-the-web-interface-with-a-specific-text-to-annotate).

I would like to link to my instance of CoreNLP server, with a specified text and specified set of annotators (i.e. without having to paste the text then click on Submit).

Rather than using GET params it's easier (as the whole frontend is static) to just parse parameters in JS.

Example URL: 
```
http://corenlp.run/#text=foo%20bar&annotators=pos,lemma,ner
```
