### PR TITLE
Bump version number for EJML.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.googlecode.efficient-java-matrix-library</groupId>
-      <artifactId>ejml</artifactId>
-      <version>0.23</version>
+      <groupId>org.ejml</groupId>
+      <artifactId>all</artifactId>
+      <version>0.29</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
In particular, the maven group id and the package prefixes are now the
same, thereby eliminating potential runtime errors for conflicting
dependencies.