### PR TITLE
[minor] Fix spanToString methods for coref mentions

### DIFF
--- a/src/edu/stanford/nlp/coref/data/Mention.java
+++ b/src/edu/stanford/nlp/coref/data/Mention.java
@@ -49,6 +49,7 @@ import edu.stanford.nlp.ling.CoreAnnotation;
 import edu.stanford.nlp.ling.CoreAnnotations;
 import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.ling.IndexedWord;
+import edu.stanford.nlp.ling.SentenceUtils;
 import edu.stanford.nlp.semgraph.SemanticGraph;
 import edu.stanford.nlp.semgraph.semgrex.SemgrexMatcher;
 import edu.stanford.nlp.semgraph.semgrex.SemgrexPattern;
@@ -167,12 +168,15 @@ public class Mention implements CoreAnnotation<Mention>, Serializable {
   public String spanToString() {
 //    synchronized(this) {
       if (spanString == null) {
-        StringBuilder os = new StringBuilder();
-        for(int i = 0; i < originalSpan.size(); i ++){
-          if(i > 0) os.append(" ");
-          os.append(originalSpan.get(i).get(CoreAnnotations.TextAnnotation.class));
+        spanString = SentenceUtils.listToOriginalTextString(originalSpan, false);
+        if (spanString == null) {
+          StringBuilder os = new StringBuilder();
+          for (int i = 0; i < originalSpan.size(); i++) {
+            if (i > 0) os.append(" ");
+            os.append(originalSpan.get(i).get(CoreAnnotations.TextAnnotation.class));
+          }
+          spanString = os.toString();
         }
-        spanString = os.toString();
       }
 //    }
     return spanString;

--- a/src/edu/stanford/nlp/dcoref/Mention.java
+++ b/src/edu/stanford/nlp/dcoref/Mention.java
@@ -47,6 +47,7 @@ import edu.stanford.nlp.ling.CoreAnnotation;
 import edu.stanford.nlp.ling.CoreAnnotations;
 import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.ling.IndexedWord;
+import edu.stanford.nlp.ling.SentenceUtils;
 import edu.stanford.nlp.trees.*;
 import edu.stanford.nlp.semgraph.SemanticGraph;
 import edu.stanford.nlp.semgraph.semgrex.SemgrexMatcher;
@@ -164,12 +165,15 @@ public class Mention implements CoreAnnotation<Mention>, Serializable {
   public String spanToString() {
 //    synchronized(this) {
       if (spanString == null) {
-        StringBuilder os = new StringBuilder();
-        for(int i = 0; i < originalSpan.size(); i ++){
-          if(i > 0) os.append(" ");
-          os.append(originalSpan.get(i).get(CoreAnnotations.TextAnnotation.class));
+        spanString = SentenceUtils.listToOriginalTextString(originalSpan, false);
+        if (spanString == null) {
+          StringBuilder os = new StringBuilder();
+          for (int i = 0; i < originalSpan.size(); i++) {
+            if (i > 0) os.append(" ");
+            os.append(originalSpan.get(i).get(CoreAnnotations.TextAnnotation.class));
+          }
+          spanString = os.toString();
         }
-        spanString = os.toString();
       }
 //    }
     return spanString;


### PR DESCRIPTION
This is a minor edit.

The previous `spanToString` method did not respect the original whitespace for tokens and was hard-coded to add one space character between each token. The new method does respect the original whitespace.

I used the `listToOriginalTextString` utility method in SentenceUtils - hope that's not frowned upon. I preserved the original code as a fallback.