### PR TITLE
Add unique matches option for CoreNLPServer Semgrex

### DIFF
--- a/src/edu/stanford/nlp/pipeline/StanfordCoreNLPServer.java
+++ b/src/edu/stanford/nlp/pipeline/StanfordCoreNLPServer.java
@@ -977,10 +977,13 @@ public class StanfordCoreNLPServer implements Runnable {
           // (get whether to filter / find)
           String filterStr = params.getOrDefault("filter", "false");
           final boolean filter = filterStr.trim().isEmpty() || "true".equalsIgnoreCase(filterStr.toLowerCase());
+          // (in case of find, get whether to only keep unique matches)
+          String uniqueStr = params.getOrDefault("unique", "false");
+          final boolean unique = uniqueStr.trim().isEmpty() || "true".equalsIgnoreCase(uniqueStr.toLowerCase());
           // (create the matcher)
           final SemgrexPattern regex = SemgrexPattern.compile(pattern);
 
-          // Run TokensRegex
+          // Run Semgrex
           return Pair.makePair(JSONOutputter.JSONWriter.objectToJSON((docWriter) -> {
             if (filter) {
               // Case: just filter sentences
@@ -992,7 +995,8 @@ public class StanfordCoreNLPServer implements Runnable {
               docWriter.set("sentences", doc.get(CoreAnnotations.SentencesAnnotation.class).stream().map(sentence -> (Consumer<JSONOutputter.Writer>) (JSONOutputter.Writer sentWriter) -> {
                 SemgrexMatcher matcher = regex.matcher(sentence.get(SemanticGraphCoreAnnotations.EnhancedPlusPlusDependenciesAnnotation.class));
                 int i = 0;
-                while (matcher.find()) {
+                // Case: find either next node or next unique node
+                while (unique ? matcher.findNextMatchingNode() : matcher.find()) {
                   sentWriter.set(Integer.toString(i), (Consumer<JSONOutputter.Writer>) (JSONOutputter.Writer matchWriter) -> {
                     IndexedWord match = matcher.getMatch();
                     matchWriter.set("text", match.word());


### PR DESCRIPTION
## Description

A "unique matches" option has been added for Semgrex queries on a CoreNLP Server.

When `unique` is set to true (and `filter` is set to false), the list of matches returned by the server contains only `unique` entries. This is useful because Semgrex users are oftentimes only interested in unique matches.

`SemgrexMatcher` already contains the `findNextMatchingNode()` function for finding the next unique match, so the `unique` option simply calls that function instead of the default `find()`.

## Example

**POST request body**
```
I ran.
```

**POST request query (without `unique`)**
```
Query: "http://localhost:9000/semgrex?pattern={} [< {} | > {}]"

Response:
{
    "sentences": [
        {
            "0": {
                "text": "ran",
                "begin": 1,
                "end": 2
            },
            "1": {
                "text": "ran",
                "begin": 1,
                "end": 2
            },
            "2": {
                "text": ".",
                "begin": 2,
                "end": 3
            },
            "3": {
                "text": "I",
                "begin": 0,
                "end": 1
            },
            "length": 4
        }
    ]
}
```

**POST request query (with `unique`)**
```
Query: "http://localhost:9000/semgrex?pattern={} [< {} | > {}]&unique=true"

Response:
{
    "sentences": [
        {
            "0": {
                "text": "ran",
                "begin": 1,
                "end": 2
            },
            "1": {
                "text": ".",
                "begin": 2,
                "end": 3
            },
            "2": {
                "text": "I",
                "begin": 0,
                "end": 1
            },
            "length": 3
        }
    ]
}
```
