### PR TITLE
StanfordCoreNLPServer: adding properties parametrization to /tokensregex, /semgrex, and /tregex

### DIFF
--- a/src/edu/stanford/nlp/pipeline/demo/corenlp-brat.js
+++ b/src/edu/stanford/nlp/pipeline/demo/corenlp-brat.js
@@ -1117,7 +1117,9 @@ $(document).ready(function() {
     // Make ajax call
     $.ajax({
       type: 'POST',
-      url: serverAddress + '/tokensregex?pattern=' + encodeURIComponent(pattern.replace("&", "\\&").replace('+', '\\+')),
+      url: serverAddress + '/tokensregex?pattern=' + encodeURIComponent(
+        pattern.replace("&", "\\&").replace('+', '\\+')) +
+        '&pipelineLanguage=' + encodeURIComponent($('#language').val()),
       data: encodeURIComponent(currentQuery),
       success: function(data) {
         $('.tokensregex_error').remove();  // Clear error messages
@@ -1149,7 +1151,9 @@ $(document).ready(function() {
     // Make ajax call
     $.ajax({
       type: 'POST',
-      url: serverAddress + '/semgrex?pattern=' + encodeURIComponent(pattern.replace("&", "\\&").replace('+', '\\+')),
+      url: serverAddress + '/semgrex?pattern=' + encodeURIComponent(
+        pattern.replace("&", "\\&").replace('+', '\\+')) +
+        '&pipelineLanguage=' + encodeURIComponent($('#language').val()),
       data: encodeURIComponent(currentQuery),
       success: function(data) {
         $('.semgrex_error').remove();  // Clear error messages
@@ -1180,7 +1184,9 @@ $(document).ready(function() {
     // Make ajax call
     $.ajax({
       type: 'POST',
-      url: serverAddress + '/tregex?pattern=' + encodeURIComponent(pattern.replace("&", "\\&").replace('+', '\\+')),
+      url: serverAddress + '/tregex?pattern=' + encodeURIComponent(
+        pattern.replace("&", "\\&").replace('+', '\\+')) +
+        '&pipelineLanguage=' + encodeURIComponent($('#language').val()),
       data: encodeURIComponent(currentQuery),
       success: function(data) {
         $('.tregex_error').remove();  // Clear error messages


### PR DESCRIPTION
_This PR may probably respond and fix the issue described here: https://github.com/stanfordnlp/CoreNLP/issues/472_

## Issue Description
`StanfordCoreNLPServer` has 4 endpoints:

1. `/` 👌
2. `/tokensregex`
3. `/semgrex`
4. `/tregex`

The first one performs the annotations over the given text, receiving `properties` and `pipelineLanguage` via query-strings.  The other three are labeled as "CoreNLP Tools", and works differently: they only accept `filter` and `pattern`.

The *problem* comes up when you are not working with the default language (English). In this scenario the last 3 enumerated endpoints won't accept any other than English.  This results in a separate annotation pipeline initialized for the "Tools" (an English pipeline), making the POS matches invalid for the three utilities.

## Solution
This change moves the `getProperties` private method from the first endpoint handler class to the container class, in order to be reused by the other endpoint handlers too.  Also there's some minor tweaks on the JS files that handles the "Tools" form submissions.

I tested this with Spanish, and after these changes it works pretty well, either using Universal Dependencies or the "distsim" tagger.  Please, note that the changes are pretty superficial.

### Before
Note that Semgrex matches `FW` for "Yo", instead of `pp0000000` as it appears in POS.
![screen shot 2017-09-09 at 9 54 01 pm](https://user-images.githubusercontent.com/314938/30245248-82876b8a-95a9-11e7-891e-00854b692660.png)

### After
Apart of me using UD, note that Semgrex matches correctly the same POS tags as above.
![screen shot 2017-09-09 at 9 53 59 pm](https://user-images.githubusercontent.com/314938/30245250-898dc78a-95a9-11e7-97de-f82a9cc5436c.png)

