### PR TITLE
StanfordCoreNLPServer: adding regexner to the available annotators list

### DIFF
--- a/src/edu/stanford/nlp/pipeline/StanfordCoreNLPServer.java
+++ b/src/edu/stanford/nlp/pipeline/StanfordCoreNLPServer.java
@@ -847,8 +847,6 @@ public class StanfordCoreNLPServer implements Runnable {
       setHttpExchangeResponseHeaders(httpExchange);
 
       Properties props = getProperties(httpExchange);
-      // Override with Required annotators for Semgrex
-      props.setProperty("annotators", "tokenize,ssplit,pos,lemma,ner");
 
       if (authenticator != null && !authenticator.test(props)) {
         respondUnauthorized(httpExchange);
@@ -970,8 +968,6 @@ public class StanfordCoreNLPServer implements Runnable {
       setHttpExchangeResponseHeaders(httpExchange);
 
       Properties props = getProperties(httpExchange);
-      // Override with Required annotators for Semgrex
-      props.setProperty("annotators", "tokenize,ssplit,pos,lemma,ner,depparse");
 
       if (authenticator != null && !authenticator.test(props)) {
         respondUnauthorized(httpExchange);
@@ -1093,8 +1089,6 @@ public class StanfordCoreNLPServer implements Runnable {
       setHttpExchangeResponseHeaders(httpExchange);
 
       Properties props = getProperties(httpExchange);
-      // Override with Required annotators for Semgrex
-      props.setProperty("annotators", "tokenize,ssplit,parse");
 
       if (authenticator != null && ! authenticator.test(props)) {
         respondUnauthorized(httpExchange);

--- a/src/edu/stanford/nlp/pipeline/demo/corenlp-brat.html
+++ b/src/edu/stanford/nlp/pipeline/demo/corenlp-brat.html
@@ -52,6 +52,7 @@
         <option value="pos"            selected > parts-of-speech    </option>
         <option value="lemma"                   > lemmas             </option>
         <option value="ner"            selected > named entities     </option>
+        <option value="regexner"                > named entities (regexner)</option>
         <option value="parse"                   > constituency parse </option>
         <option value="depparse"       selected > dependency parse   </option>
         <option value="openie"         selected > openie             </option>


### PR DESCRIPTION
## Enhancement Description

### Limitation

Currently `StanfordCoreNLPServer` utility does not allow the use of `RegexNERAnnotator`.  There are several reasons it isn't working:

1. In the main tool, there is no option for the `regexner` annotator (can't pick it).
2. If the option was there, the annotator may not display the NER annotators because it's checking for the first token of the first sentence to contain the `.ner` property.  This is not always the case with `RegexNERAnnotator`.  At least empirically, I proved that this annotator does not fulfill all the tokens with the background symbol.
3. Once fixing 1) and 2), the `TokensRegex`, `Semgrex` and `Tregex` utilities will not match the same annotations, because they have the annotators overridden in the back end.  Now they're forcing `ner`.

### Approach

In order to solve the issues described above, the following approach was taken in this PR:

1. Added the `regexner` option to the multi-select field.
2. Change the way the front-end checks for annotations availability (not only looking at the first word).  This is instead of forcing `RegexNERAnnotator` to set background symbols to all the non tagged words (that might be another option).
3. `TokensRegex`, `Semgrex` and `Tregex` to use the same annotators as the ones specified above in the muli-select.  Missing annotators from the selection (that are required) will be automatically added.

### Use case

With this patch, I was able to successfully create a RegexNER mapping file, pass it by configuration (`regexner.mapping` at `-serverPropperties` file), then use the NER annotations from all the tools. at port 9000, using the Spanish language.

![screen shot 2017-09-22 at 12 32 04 pm](https://user-images.githubusercontent.com/314938/30752582-1a3a6f8e-9f93-11e7-99d3-3ed912b606a4.png)

Thanks!