### PR TITLE
Don't swallow Errors in MulticoreWrapper

### DIFF
--- a/src/edu/stanford/nlp/util/concurrent/MulticoreWrapper.java
+++ b/src/edu/stanford/nlp/util/concurrent/MulticoreWrapper.java
@@ -251,19 +251,16 @@ public class MulticoreWrapper<I,O> {
 
     @Override
     public Integer call() {
+      O result = null;
       try {
-        O result = processor.process(item);
-        QueueItem<O> output = new QueueItem<>(result, itemId);
-        callback.call(output, processorId);
-        return itemId;
-      
-      } catch (Exception e) {
+        result = processor.process(item);
+      } catch (Exception | Error e) {
         e.printStackTrace();
         // Hope that the consumer knows how to handle null!
-        QueueItem<O> output = new QueueItem<>(null, itemId);
-        callback.call(output, processorId);
-        return itemId;
       }
+      QueueItem<O> output = new QueueItem<>(result, itemId);
+      callback.call(output, processorId);
+      return itemId;
     }
   }
 


### PR DESCRIPTION
If an `Error` (e.g., `OutOfMemoryError`, `ClassNotFoundError`) is thrown by a multithreaded job, the thread is never returned to the pool, and the `MulticoreWrapper` eventually hangs infinitely.

This change will A) catch `Errors` and print the stack trace, B) always calls the callback, to return to the thread pool.

I think it would be better to somehow bubble the exception/error to the caller. But this is the minimal change to at least see the error message printed and allow the caller to fail (when seeing a null value).