### PR TITLE
Avoid shrinking qn m size to 0 on out of memory.

### DIFF
--- a/src/edu/stanford/nlp/optimization/QNMinimizer.java
+++ b/src/edu/stanford/nlp/optimization/QNMinimizer.java
@@ -1068,7 +1068,7 @@ public class QNMinimizer implements Minimizer<DiffFunction>, HasEvaluators  {
         sayln("** program by checking the QNMinimizer.wasSuccessful() method.");
         break;
       } catch (OutOfMemoryError oome) {
-        if ( ! qn.s.isEmpty()) {
+        if ( qn.s.size() > 1) {
           qn.s.remove(0);
           qn.y.remove(0);
           qn.rho.remove(0);


### PR DESCRIPTION
This could cause an infinite loop, qn.mem must remain at least 1. We can't work with 0 candidates.