### PR TITLE
Optimize feature generation 

### DIFF
--- a/itest/src/edu/stanford/nlp/ie/NERFeatureFactoryITest.java
+++ b/itest/src/edu/stanford/nlp/ie/NERFeatureFactoryITest.java
@@ -41,13 +41,17 @@ public class NERFeatureFactoryITest extends TestCase {
     NERFeatureFactory<CoreLabel> factory = new NERFeatureFactory<>();
     factory.init(flags);
 
-    Set<String> features;
-    features = new HashSet<String>(factory.featuresC(paddedSentence, 4));
+    Set<String> features = new HashSet<String>();
+    NERFeatureFactory.FeatureCollector collector = new NERFeatureFactory.FeatureCollector(features);
+    factory.featuresC(paddedSentence, 4, collector);
     checkFeatures(features, "BAR-GAZ", "BAZ-GAZ", "FOO-GAZ", "BAR-GAZ2", "BAZ-GAZ2", "FOO-GAZ1", "John-WORD");
-    features = new HashSet<String>(factory.featuresC(paddedSentence, 5));
+    features.clear();
+    factory.featuresC(paddedSentence, 5, collector);
     checkFeatures(features, "BAR-GAZ", "BAZ-GAZ", "BAR-GAZ2", "BAZ-GAZ2", "Bauer-WORD");
-    features = new HashSet<String>(factory.featuresC(paddedSentence, 6));
+    features.clear();
+    factory.featuresC(paddedSentence, 6, collector);
     checkFeatures(features, "has-WORD");
+    features.clear();
   }
 
 }


### PR DESCRIPTION
This reduces the repeated string concatenations when generating NER features.

Previously, for each clique, we would build a set of strings,
then postfix each with the clique (which means creating another string).

The new helper class handles (most) of the concatenations with a shared buffer,
thus reducing the number of temporary string copies substantially,
which means much less work for the garbage collector, and thus higher performance.

(No, JVM would probably not optimize away all the interim strings. They 'escape'
scope via the collections, so escape analysis will not help.)

Note: this also includes #613