### PR TITLE
Speed up file parsing.

### DIFF
--- a/src/edu/stanford/nlp/ling/CoreLabel.java
+++ b/src/edu/stanford/nlp/ling/CoreLabel.java
@@ -136,6 +136,20 @@ public class CoreLabel extends ArrayCoreMap implements AbstractCoreLabel, HasCat
     initFromStrings(keys, values);
   }
 
+  /**
+   * This constructor attempts uses preparsed Class keys.
+   * It's mainly useful for reading from a file.
+   *
+   * @param keys Array of key classes
+   * @param values Array of values (as String)
+   */
+  @SuppressWarnings("rawtypes")
+  public CoreLabel(Class[] keys, String[] values) {
+    super(keys.length);
+    //this.map = new ArrayCoreMap();
+    initFromStrings(keys, values);
+  }
+
   /** This is provided as a simple way to make a CoreLabel for a word from a String.
    *  It's often useful in fixup or test code. It sets all three of the Text, OriginalText,
    *  and Value annotations to the given value.
@@ -163,7 +177,7 @@ public class CoreLabel extends ArrayCoreMap implements AbstractCoreLabel, HasCat
   public static final Map<Class<? extends GenericAnnotation>, String> genericValues = Generics.newHashMap();
 
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"})
   private void initFromStrings(String[] keys, String[] values) {
     if (keys.length != values.length) {
       throw new UnsupportedOperationException("Argument array lengths differ: " +
@@ -227,6 +241,51 @@ public class CoreLabel extends ArrayCoreMap implements AbstractCoreLabel, HasCat
     }
   }
 
+  @SuppressWarnings("rawtypes")
+  public static Class[] parseStringKeys(String[] keys) {
+    Class[] classes = new Class[keys.length];
+    for (int i = 0; i < keys.length; i++) {
+      String key = keys[i];
+      classes[i] = AnnotationLookup.toCoreKey(key);
+
+      //now work with the key we got above
+      if (classes[i] == null)
+        throw new UnsupportedOperationException("Unknown key " + key);
+    }
+    return classes;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private void initFromStrings(Class[] keys, String[] values) {
+    if (keys.length != values.length) {
+      throw new UnsupportedOperationException("Argument array lengths differ: " +
+              Arrays.toString(keys) + " vs. " + Arrays.toString(values));
+    }
+    for (int i = 0; i < keys.length; i++) {
+      Class coreKeyClass = keys[i];
+      String value = values[i];
+      try {
+        Class<?> valueClass = AnnotationLookup.getValueType(coreKeyClass);
+        if(valueClass.equals(String.class)) {
+          this.set(coreKeyClass, values[i]);
+        } else if(valueClass == Integer.class) {
+          this.set(coreKeyClass, Integer.parseInt(values[i]));
+        } else if(valueClass == Double.class) {
+          this.set(coreKeyClass, Double.parseDouble(values[i]));
+        } else if(valueClass == Long.class) {
+          this.set(coreKeyClass, Long.parseLong(values[i]));
+        } else {
+          throw new RuntimeException("Can't handle " + valueClass);
+        }
+      } catch (Exception e) {
+        // unexpected value type
+        throw new UnsupportedOperationException("CORE: CoreLabel.initFromStrings: "
+            + "Bad type for " + coreKeyClass.getSimpleName()
+            + ". Value was: " + value
+            + "; expected "+AnnotationLookup.getValueType(coreKeyClass), e);
+      }
+    }
+  }
 
   private static class CoreLabelFactory implements LabelFactory {
 

--- a/src/edu/stanford/nlp/sequences/CoNLLDocumentReaderAndWriter.java
+++ b/src/edu/stanford/nlp/sequences/CoNLLDocumentReaderAndWriter.java
@@ -91,16 +91,16 @@ public class CoNLLDocumentReaderAndWriter implements DocumentReaderAndWriter<Cor
       Collection<String> docs = new ArrayList<>();
       ObjectBank<String> ob = ObjectBank.getLineIterator(r);
       StringBuilder current = new StringBuilder();
+      Matcher matcher = docPattern.matcher("");
       for (String line : ob) {
-        if (docPattern.matcher(line).lookingAt()) {
+        if (matcher.reset(line).lookingAt()) {
           // Start new doc, store old one if non-empty
           if (current.length() > 0) {
             docs.add(current.toString());
-            current = new StringBuilder();
+            current.setLength(0);
           }
         }
-        current.append(line);
-        current.append('\n');
+        current.append(line).append('\n');
       }
       if (current.length() > 0) {
         docs.add(current.toString());
@@ -160,7 +160,7 @@ public class CoNLLDocumentReaderAndWriter implements DocumentReaderAndWriter<Cor
         wi.setWord(bits[1]);
       } else {
         wi.setWord(bits[0]);
-        }
+      }
       wi.set(CoreAnnotations.LemmaAnnotation.class, bits[1]);
       wi.setTag(bits[2]);
       wi.set(CoreAnnotations.ChunkAnnotation.class, bits[3]);


### PR DESCRIPTION
Two improvements to file parsing (e.g. for CoNLL):

1. reuse Matcher and StringBuilder to reduce garbage collection
2. parse the column mapping (map parameter) only once into annotation classes