### PR TITLE
Add taxonomy abbreviations to lexer

### DIFF
--- a/src/edu/stanford/nlp/process/PTBLexer.flex
+++ b/src/edu/stanford/nlp/process/PTBLexer.flex
@@ -774,12 +774,13 @@ ABNUM = tel|est|ext|sq
    is now caseless.  We don't want to have it recognized for P.  Both
    p. and P. are now under ABBREV4. ABLIST also went away as no-op [a-e] */
 ABPTIT = Jr|Sr|Bros|(Ed|Ph)\.D|Esq
+ABTAXONOMY = sp|cf|aff|gen
 
 /* ABBREV1 abbreviations are normally followed by lower case words.
  *  If they're followed by an uppercase one, we assume there is also a
  *  sentence boundary.
  */
-ABBREV1 = ({ABMONTH}|{ABDAYS}|{ABSTATE}|{ABCOMP}|{ABNUM}|{ABPTIT}|etc|al|seq|Bldg|Pls|wrt)\.
+ABBREV1 = ({ABMONTH}|{ABDAYS}|{ABSTATE}|{ABCOMP}|{ABNUM}|{ABPTIT}|{ABTAXONOMY}|etc|al|seq|Bldg|Pls|wrt)\.
 
 /* --- This block becomes ABBREV2 and is usually followed by upper case words. --- */
 /* In the caseless world S.p.A. "Società Per Azioni (Italian: shared company)" is got as a regular acronym */


### PR DESCRIPTION
Hello, I have a feature request:

I work with taxonomic literature, and often this kind of sentences show up:

"Microporella cf. ciliata is found in India."
"Micropora sp. is a fossil."
"Mrgaretta aff. tenuis is another animal."
"Wanganuri gen. nov. is an invented genus."

These are standard latin abbreviations (https://en.wikipedia.org/wiki/List_of_Latin_abbreviations), and I would like for them to be tokenized as units. This way I can have more precise sentence boundaries.

This contribution is public domain. I ran all tests, one skipped and none failed. If there is any problem with this implementation I would like to cooperate to find a compromise or better solution.

Best regards,
Bjørn Tore Kopperud
