### PR TITLE
Optimize Viterbi implementation

### DIFF
--- a/src/edu/stanford/nlp/sequences/ExactBestSequenceFinder.java
+++ b/src/edu/stanford/nlp/sequences/ExactBestSequenceFinder.java
@@ -39,149 +39,38 @@ public class ExactBestSequenceFinder implements BestSequenceFinder  {
 
   private static Pair<int[], Double> bestSequence(SequenceModel ts, double[][] linearConstraints) {
     // Set up tag options
-    int length = ts.length();
-    int leftWindow = ts.leftWindow();
-    int rightWindow = ts.rightWindow();
-    int padLength = length + leftWindow + rightWindow;
+    final int length = ts.length();
+    final int leftWindow = ts.leftWindow();
+    final int rightWindow = ts.rightWindow();
+    final int padLength = length + leftWindow + rightWindow;
     if (linearConstraints != null && linearConstraints.length != padLength)
       throw new RuntimeException("linearConstraints.length (" +  linearConstraints.length + ") does not match padLength (" + padLength + ") of SequenceModel" + ", length=="+length+", leftW="+leftWindow+", rightW="+rightWindow);
     int[][] tags = new int[padLength][];
     int[] tagNum = new int[padLength];
     if (DEBUG) { log.info("Doing bestSequence length " + length + "; leftWin " + leftWindow + "; rightWin " + rightWindow + "; padLength " + padLength); }
     for (int pos = 0; pos < padLength; pos++) {
-      if (Thread.interrupted()) {  // Allow interrupting
-        throw new RuntimeInterruptedException();
-      }
       tags[pos] = ts.getPossibleValues(pos);
       tagNum[pos] = tags[pos].length;
       if (DEBUG) { log.info("There are " + tagNum[pos] + " values at position " + pos + ": " + Arrays.toString(tags[pos])); }
     }
 
-    int[] tempTags = new int[padLength];
-
     // Set up product space sizes
-    int[] productSizes = new int[padLength];
-
-    int curProduct = 1;
-    for (int i = 0; i < leftWindow + rightWindow; i++) {
-      curProduct *= tagNum[i];
-    }
-    for (int pos = leftWindow + rightWindow; pos < padLength; pos++) {
-      if (Thread.interrupted()) {  // Allow interrupting
-        throw new RuntimeInterruptedException();
-      }
-      if (pos > leftWindow + rightWindow) {
-        curProduct /= tagNum[pos - leftWindow - rightWindow - 1]; // shift off
-      }
-      curProduct *= tagNum[pos]; // shift on
-      productSizes[pos - rightWindow] = curProduct;
-    }
+    int[] productSizes = initProductSizes(ts, tagNum, new int[padLength]);
 
     // Score all of each window's options
-    double[][] windowScore = new double[padLength][];
-    for (int pos = leftWindow; pos < leftWindow + length; pos++) {
-      if (Thread.interrupted()) {  // Allow interrupting
-        throw new RuntimeInterruptedException();
-      }
-      if (DEBUG) { log.info("scoring word " + pos + " / " + (leftWindow + length) + ", productSizes =  " + productSizes[pos] + ", tagNum = " + tagNum[pos] + "..."); }
-      windowScore[pos] = new double[productSizes[pos]];
-      Arrays.fill(tempTags, tags[0][0]);
-      if (DEBUG) { log.info("windowScore[" + pos + "] has size (productSizes[pos]) " + windowScore[pos].length); }
-
-      for (int product = 0; product < productSizes[pos]; product++) {
-        if (Thread.interrupted()) {  // Allow interrupting
-          throw new RuntimeInterruptedException();
-        }
-        int p = product;
-        int shift = 1;
-        for (int curPos = pos + rightWindow; curPos >= pos - leftWindow; curPos--) {
-          tempTags[curPos] = tags[curPos][p % tagNum[curPos]];
-          p /= tagNum[curPos];
-          if (curPos > pos) {
-            shift *= tagNum[curPos];
-          }
-        }
-
-        // Here now you get ts.scoresOf() for all classifications at a position at once, whereas the old code called ts.scoreOf() on each item.
-        // CDM May 2007: The way this is done gives incorrect results if there are repeated values in the values of ts.getPossibleValues(pos) -- in particular if the first value of the array is repeated later.  I tried replacing it with the modulo version, but that only worked for left-to-right, not bidirectional inference, but I still think that if you sorted things out, you should be able to do it with modulos and the result would be conceptually simpler and robust to repeated values.  But in the meantime, I fixed the POS tagger to not give repeated values (which was a bug in the tagger).
-        if (tempTags[pos] == tags[pos][0]) {
-          // get all tags at once
-          double[] scores = ts.scoresOf(tempTags, pos);
-          if (DEBUG) { log.info("Matched at array index [product] " + product + "; tempTags[pos] == tags[pos][0] == " + tempTags[pos]); }
-          if (DEBUG) { log.info("For pos " + pos + " scores.length is " + scores.length + "; tagNum[pos] = " + tagNum[pos] + "; windowScore[pos].length = " + windowScore[pos].length); }
-          if (DEBUG) { log.info("scores: " + Arrays.toString(scores)); }
-          // fill in the relevant windowScores
-          for (int t = 0; t < tagNum[pos]; t++) {
-            if (DEBUG) { log.info("Setting value of windowScore[" + pos + "][" + product + "+" + t + "*" + shift + "] = " + scores[t]); }
-            windowScore[pos][product + t * shift] = scores[t];
-          }
-        }
-      }
-    }
+    int[] tempTags = new int[padLength];
+    double[][] windowScore = computeWindowScore(ts, tags, tagNum, tempTags, productSizes);
 
     // Set up score and backtrace arrays
     double[][] score = new double[padLength][];
     int[][] trace = new int[padLength][];
     for (int pos = 0; pos < padLength; pos++) {
-      if (Thread.interrupted()) {  // Allow interrupting
-        throw new RuntimeInterruptedException();
-      }
       score[pos] = new double[productSizes[pos]];
       trace[pos] = new int[productSizes[pos]];
     }
 
     // Do forward Viterbi algorithm
-
-    // loop over the classification spot
-    //log.info();
-    for (int pos = leftWindow; pos < length + leftWindow; pos++) {
-      //log.info(".");
-      // loop over window product types
-      for (int product = 0; product < productSizes[pos]; product++) {
-        if (Thread.interrupted()) {  // Allow interrupting
-          throw new RuntimeInterruptedException();
-        }
-        // check for initial spot
-        if (pos == leftWindow) {
-          // no predecessor type
-          score[pos][product] = windowScore[pos][product];
-          if (linearConstraints != null) {
-            if (DEBUG) {
-              if (linearConstraints[pos][product % tagNum[pos]] != 0) {
-                log.info("Applying linear constraints=" + linearConstraints[pos][product % tagNum[pos]] + " to preScore="+ windowScore[pos][product] + " at pos="+pos+" for tag="+(product % tagNum[pos]));
-              }
-            }
-            score[pos][product] += linearConstraints[pos][product % tagNum[pos]];
-          }
-          trace[pos][product] = -1;
-        } else {
-          // loop over possible predecessor types
-          score[pos][product] = Double.NEGATIVE_INFINITY;
-          trace[pos][product] = -1;
-          int sharedProduct = product / tagNum[pos + rightWindow];
-          int factor = productSizes[pos] / tagNum[pos + rightWindow];
-          for (int newTagNum = 0; newTagNum < tagNum[pos - leftWindow - 1]; newTagNum++) {
-            int predProduct = newTagNum * factor + sharedProduct;
-            double predScore = score[pos - 1][predProduct] + windowScore[pos][product];
-
-            if (linearConstraints != null) {
-              if (DEBUG) {
-                if (pos == 2 && linearConstraints[pos][product % tagNum[pos]] != 0) {
-                  log.info("Applying linear constraints=" + linearConstraints[pos][product % tagNum[pos]] + " to preScore="+ predScore + " at pos="+pos+" for tag="+(product % tagNum[pos]));
-                  log.info("predScore:" + predScore + " = score["+(pos - 1)+"]["+predProduct+"]:" + score[pos - 1][predProduct] + " + windowScore["+pos+"]["+product+"]:" + windowScore[pos][product]);
-                }
-              }
-              predScore += linearConstraints[pos][product % tagNum[pos]];
-            }
-
-            if (predScore > score[pos][product]) {
-              score[pos][product] = predScore;
-              trace[pos][product] = predProduct;
-            }
-          }
-        }
-      }
-    }
+    forwardViterbi(linearConstraints, length, leftWindow, rightWindow, tagNum, productSizes, windowScore, score, trace);
 
     // Project the actual tag sequence
     double bestFinalScore = Double.NEGATIVE_INFINITY;
@@ -203,5 +92,140 @@ public class ExactBestSequenceFinder implements BestSequenceFinder  {
       tempTags[pos - leftWindow] = tags[pos - leftWindow][bestCurrentProduct / (productSizes[pos] / tagNum[pos - leftWindow])];
     }
     return new Pair<>(tempTags, bestFinalScore);
+  }
+
+  private static int[] initProductSizes(final SequenceModel ts, int[] tagNum, int[] productSizes) {
+    final int leftWindow = ts.leftWindow();
+    final int rightWindow = ts.rightWindow();
+    final int padLength = productSizes.length;
+
+    int curProduct = 1;
+    for (int i = 0; i < leftWindow + rightWindow; i++) {
+      curProduct *= tagNum[i];
+    }
+    for (int pos = leftWindow + rightWindow; pos < padLength; pos++) {
+      if (pos > leftWindow + rightWindow) {
+        curProduct /= tagNum[pos - leftWindow - rightWindow - 1]; // shift off
+      }
+      curProduct *= tagNum[pos]; // shift on
+      productSizes[pos - rightWindow] = curProduct;
+    }
+    return productSizes;
+  }
+
+  private static double[][] computeWindowScore(SequenceModel ts, int[][] tags, int[] tagNum, int[] tempTags, int[] productSizes) {
+    final int length = ts.length();
+    final int leftWindow = ts.leftWindow();
+    final int rightWindow = ts.rightWindow();
+    final int padLength = length + leftWindow + rightWindow;
+    double[][] windowScore = new double[padLength][];
+    for (int pos = leftWindow; pos < leftWindow + length; pos++) {
+      if (Thread.interrupted()) {  // Allow interrupting
+        throw new RuntimeInterruptedException();
+      }
+      // Local constants, to avoid repeated array access.
+      final int tagNum_pos = tagNum[pos];
+      final int productSizes_pos = productSizes[pos];
+      final double[] windowScore_pos = windowScore[pos] = new double[productSizes_pos];
+      if (DEBUG) { log.info("scoring word " + pos + " / " + (leftWindow + length) + ", productSizes =  " + productSizes_pos + ", tagNum = " + tagNum_pos + "..."); }
+      Arrays.fill(tempTags, tags[0][0]);
+      if (DEBUG) { log.info("windowScore[" + pos + "] has size (productSizes[pos]) " + windowScore_pos.length); }
+
+      for (int product = 0; product < productSizes_pos; product++) {
+        int p = product;
+        int shift = 1;
+        for (int curPos = pos + rightWindow, endCurPos = pos - leftWindow; curPos >= endCurPos; curPos--) {
+          final int tn = tagNum[curPos];
+          tempTags[curPos] = tags[curPos][p % tn];
+          p /= tn;
+          if (curPos > pos) {
+            shift *= tn;
+          }
+        }
+
+        // Here now you get ts.scoresOf() for all classifications at a position at once, whereas the old code called ts.scoreOf() on each item.
+        // CDM May 2007: The way this is done gives incorrect results if there are repeated values in the values of ts.getPossibleValues(pos) -- in particular if the first value of the array is repeated later.  I tried replacing it with the modulo version, but that only worked for left-to-right, not bidirectional inference, but I still think that if you sorted things out, you should be able to do it with modulos and the result would be conceptually simpler and robust to repeated values.  But in the meantime, I fixed the POS tagger to not give repeated values (which was a bug in the tagger).
+        if (tempTags[pos] == tags[pos][0]) {
+          // get all tags at once
+          double[] scores = ts.scoresOf(tempTags, pos);
+          if (DEBUG) {
+            log.info("Matched at array index [product] " + product + "; tempTags[pos] == tags[pos][0] == " + tempTags[pos]);
+            log.info("For pos " + pos + " scores.length is " + scores.length + "; tagNum[pos] = " + tagNum_pos + "; windowScore[pos].length = " + windowScore_pos.length);
+            log.info("scores: " + Arrays.toString(scores));
+          }
+          // fill in the relevant windowScores
+          for (int t = 0; t < tagNum_pos; t++) {
+            if (DEBUG) { log.info("Setting value of windowScore[" + pos + "][" + product + "+" + t + "*" + shift + "] = " + scores[t]); }
+            windowScore_pos[product + t * shift] = scores[t];
+          }
+        }
+      }
+    }
+    return windowScore;
+  }
+
+  private static void forwardViterbi(double[][] linearConstraints, final int length, final int leftWindow, final int rightWindow, int[] tagNum, int[] productSizes, double[][] windowScore, double[][] score, int[][] trace) {
+    int pos = leftWindow, endpos = length + leftWindow;
+    // initial spot:
+    for (int product = 0, products = productSizes[pos]; product < products; product++) {
+      // Local copies, to reduce array lookups.
+      final double[] score_pos = score[pos];
+      final int[] trace_pos = trace[pos];
+      final double[] linearConstraints_pos = linearConstraints != null ? linearConstraints[pos] : null;
+      final int tagNum_pos = tagNum[pos];
+      final double[] windowScore_pos = windowScore[pos];
+      // no predecessor type
+      score_pos[product] = windowScore_pos[product];
+      if (linearConstraints_pos != null) {
+        if (DEBUG) {
+          if (linearConstraints_pos[product % tagNum_pos] != 0) {
+            log.info("Applying linear constraints=" + linearConstraints_pos[product % tagNum_pos] + " to preScore="+ windowScore_pos[product] + " at pos="+pos+" for tag="+(product % tagNum_pos));
+          }
+        }
+        score_pos[product] += linearConstraints_pos[product % tagNum_pos];
+      }
+      trace_pos[product] = -1;
+    }
+    // loop over the remaining classification spots
+    //log.info();
+    for (pos++; pos < endpos; pos++) {
+      if (Thread.interrupted()) {  // Allow interrupting
+        throw new RuntimeInterruptedException();
+      }
+      // Local copies, to reduce array lookups.
+      final double[] score_pos = score[pos];
+      final int[] trace_pos = trace[pos];
+      final double[] linearConstraints_pos = linearConstraints != null ? linearConstraints[pos] : null;
+      final int tagNum_pos = tagNum[pos];
+      final double[] windowScore_pos = windowScore[pos];
+      //log.info(".");
+      // loop over window product types
+      for (int product = 0, products = productSizes[pos]; product < products; product++) {
+        // loop over possible predecessor types
+        score_pos[product] = Double.NEGATIVE_INFINITY;
+        trace_pos[product] = -1;
+        int sharedProduct = product / tagNum[pos + rightWindow];
+        int factor = products / tagNum[pos + rightWindow];
+        for (int newTagNum = 0; newTagNum < tagNum[pos - leftWindow - 1]; newTagNum++) {
+          int predProduct = newTagNum * factor + sharedProduct;
+          double predScore = score[pos - 1][predProduct] + windowScore_pos[product];
+
+          if (linearConstraints_pos != null) {
+            if (DEBUG) {
+              if (pos == 2 && linearConstraints_pos[product % tagNum_pos] != 0) {
+                log.info("Applying linear constraints=" + linearConstraints_pos[product % tagNum_pos] + " to preScore="+ predScore + " at pos="+pos+" for tag="+(product % tagNum_pos));
+                log.info("predScore:" + predScore + " = score["+(pos - 1)+"]["+predProduct+"]:" + score[pos - 1][predProduct] + " + windowScore["+pos+"]["+product+"]:" + windowScore_pos[product]);
+              }
+            }
+            predScore += linearConstraints_pos[product % tagNum_pos];
+          }
+
+          if (predScore > score_pos[product]) {
+            score_pos[product] = predScore;
+            trace_pos[product] = predProduct;
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Optimize the Viterbi code by three key means:

* Avoid redundant array accesses and computations by using much local variables (yes, theoretically a good compiler would recognize and avoid these redundancies, but as far as I can tell, hotspot usually doesn't, and local references for nested arrays help)
* Break into multiple methods, so they can be optimized independently by hotspot. Hotspot works great with a single hot loop in a method, but has limitations if you have >2 hot loops in the same method (because it might optimize the first loop before it has enough/any statistics on the later loops).
* Instead of computing division and modulo, use division and manually compute remainder, since a-b*c will usually be faster than a modulo.

All of this is very technical, and not pretty (well, breaking into multiple methods is not bad). But as this is a very central method, such optimizations may be worth it.