### PR TITLE
Updated gh-pages for link to docker image

### DIFF
--- a/_pages/corenlp-server.md
+++ b/_pages/corenlp-server.md
@@ -234,8 +234,12 @@ The classpath must include all of the CoreNLP dependencies. The memory requireme
 
 ### Docker
 
+```
+Docker repository: https://hub.docker.com/r/frnkenstien/corenlp
+docker pull frnkenstien/corenlp
+```
 If running the server under docker, the container’s port 9000 has to be published to the host. Give a command like:
-`docker run -p 9000:9000 --name coreNLP --rm -i -t motiz88/corenlp`. If, when going to `localhost:9000/`, you see the error 
+`docker run -p 9000:9000 --name coreNLP --rm -i -t frnkenstien/corenlp`. If, when going to `localhost:9000/`, you see the error 
 `This site can’t be reached. localhost refused to connect`, then this is what you failed to do!
 
 ### Stopping the Server


### PR DESCRIPTION
Updated gh pages for link to docker image which uses the latest stanford corenlp