### PR TITLE
Add IsNewlineAnnotation in Chinese segmentation output

### DIFF
--- a/src/edu/stanford/nlp/pipeline/ChineseSegmenterAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/ChineseSegmenterAnnotator.java
@@ -425,10 +425,14 @@ public class ChineseSegmenterAnnotator implements Annotator  {
     if (separatorPattern.matcher(tokenText).matches()) {
       // Map to CoreNLP newline token
       tokenText = AbstractTokenizer.NEWLINE_TOKEN;
+      token.set(CoreAnnotations.IsNewlineAnnotation.class, true);
     } else if (doNormalization && normalizeSpace) {
       tokenText = tokenText.replace(' ', '\u00A0'); // change space to non-breaking space
+			token.set(CoreAnnotations.IsNewlineAnnotation.class, false);
+    } else {
+			token.set(CoreAnnotations.IsNewlineAnnotation.class, false);
     }
-
+    
     token.setWord(tokenText);
     token.setValue(tokenText);
     token.set(CoreAnnotations.CharacterOffsetBeginAnnotation.class, charOffsetBegin);


### PR DESCRIPTION
Fixing issue where, in v3.9.1 (and possibly 3.9), Chinese segmentation output can no longer be passed to sentence splitting (e.g. annotators = segment, ssplit, pos). Adding in the CoreAnnotations.IsNewlineAnnotation.class in the segmentation output.