### PR TITLE
xception in thread "main" java.lang.IllegalArgumentException: No annotator named mention

### DIFF
--- a/_pages/coref.md
+++ b/_pages/coref.md
@@ -69,7 +69,7 @@ public class CorefExample {
   public static void main(String[] args) throws Exception {
     Annotation document = new Annotation("Barack Obama was born in Hawaii.  He is the president. Obama was elected in 2008.");
     Properties props = new Properties();
-    props.setProperty("annotators", "tokenize,ssplit,pos,lemma,ner,parse,mention,coref");
+    props.setProperty("annotators", "tokenize,ssplit,pos,lemma,ner,parse,coref.mention,coref");
     StanfordCoreNLP pipeline = new StanfordCoreNLP(props);
     pipeline.annotate(document);
     System.out.println("---");


### PR DESCRIPTION
I believe that there has been a change in the way the mention annotator is called. 
It isn't working anymore without prefixing it with coref.

If you know that this is going to be the standard way of calling the mention annotator please let me know so that I can find other mentions of that annotator and change them