### PR TITLE
TokensRegexNERAnnotator | Implemented per-file header declarations and header=true 

### DIFF
--- a/src/edu/stanford/nlp/pipeline/TokensRegexNERAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/TokensRegexNERAnnotator.java
@@ -257,8 +257,8 @@ public class TokensRegexNERAnnotator implements Annotator  {
     				mappingLine = "header=true, "+ mappingLine;
     				mappings[i] = mappingLine;
     			}
-    			else if (!mappingLine.toLowerCase().matches("header\\s*=\\s*true")){
-    				throw new Error("Error! The annotator header property is set to true, but a different options has been provided for mapping file: " + mappingLine);
+    			else if (!Pattern.compile("header\\s*=\\s*true").matcher(mappingLine.toLowerCase()).find()){
+    				throw new Error("The annotator header property is set to true, but a different option has been provided for mapping file: " + mappingLine);
     			}
     			
     		}
@@ -852,7 +852,7 @@ public class TokensRegexNERAnnotator implements Annotator  {
       return SEMICOLON_DELIMITERS_PATTERN.split(mappingFiles);
     }
   }
-  private static String[] processPerFileOptions(String annotatorName, String[] mappings, List<Boolean> ignoreCaseList, List<Pattern> validPosPatternList, List<String[]> filesHeaderList, boolean ignoreCase, Pattern validPosPattern, String[] headerList, String[] annotationFieldnames, List<Class> annotationFields) {
+  private static String[] processPerFileOptions(String annotatorName, String[] mappings, List<Boolean> ignoreCaseList, List<Pattern> validPosPatternList, List<String[]> headerList, boolean ignoreCase, Pattern validPosPattern, String[] headerFields, String[] annotationFieldnames, List<Class> annotationFields) {
     Integer numMappingFiles = mappings.length;
     for (int index = 0; index < numMappingFiles; index++) {
       boolean ignoreCaseSet = false;
@@ -883,36 +883,36 @@ public class TokensRegexNERAnnotator implements Annotator  {
                 validPosPatternSet = true;
                 break;
               case "header":
-          	  	String headerItems = optionAndValue[1].trim();
-          	  	String[] thisFileheaderList = COMMA_DELIMITERS_PATTERN.split(headerItems);
+          	  	String header = optionAndValue[1].trim();
+          	  	String[] headerItems = header.split("\\s+");
           	  	headerSet = true;
           	  	
-          	  	if (thisFileheaderList.length == 1 && thisFileheaderList[0].equalsIgnoreCase("true")) {
+          	  	if (headerItems.length == 1 && headerItems[0].equalsIgnoreCase("true")) {
           	  		try {
-          	  				BufferedReader br = IOUtils.readerFromString(filePath);
-							String headerLine = br.readLine();
-							IOUtils.closeIgnoringExceptions(br);
-							thisFileheaderList = headerLine.split("\\t");
-						} catch (IOException e) {
-							e.printStackTrace();
+      	  				BufferedReader br = IOUtils.readerFromString(filePath);
+						String headerLine = br.readLine();
+						IOUtils.closeIgnoringExceptions(br);
+						headerItems = headerLine.split("\\t");
+					} catch (IOException e) {
+						e.printStackTrace();
 						}
           	  	}
           	  	            	  	
-          	  	filesHeaderList.add(thisFileheaderList);
+          	  	headerList.add(headerItems);
           	  	
-	        	      for (String field : thisFileheaderList) {
-	        	          if (!predefinedHeaderFields.contains(field) && !Arrays.asList(annotationFieldnames).contains(field)) {
+        	        for (String field : headerItems) {
+        	        		if (!predefinedHeaderFields.contains(field) && !Arrays.asList(annotationFieldnames).contains(field)) {
 	        	              Class fieldClass = EnvLookup.lookupAnnotationKeyWithClassname(null, field);
 	        	              if (fieldClass == null) {
-		            	        throw new RuntimeException( "Not recognized annotation class field \"" + field + "\" in header for mapping file " + allOptions[numOptions -1]);
+        	            	  		throw new RuntimeException( "Not recognized annotation class field \"" + field + "\" in header for mapping file " + allOptions[numOptions -1]);
 	        	              }
 	        	              else {
-	        	            	  annotationFields.add(fieldClass);
-	        	            	  annotationFieldnames = Arrays.copyOf(annotationFieldnames, annotationFieldnames.length + 1);
-	        	            	  annotationFieldnames[annotationFieldnames.length - 1] = field;
+		        	            	annotationFields.add(fieldClass);
+		        	            	annotationFieldnames = Arrays.copyOf(annotationFieldnames, annotationFieldnames.length + 1);
+		        	            	annotationFieldnames[annotationFieldnames.length - 1] = field;
 	        	              }
 	        	          }
-	        	      }
+	        	      	}
 	        	      break;
 	        	      
               default:
@@ -932,7 +932,7 @@ public class TokensRegexNERAnnotator implements Annotator  {
       }
       
       if (!headerSet) {
-  	  	filesHeaderList.add(headerList);
+    	  	headerList.add(headerFields);
       }
     }
     

--- a/src/edu/stanford/nlp/pipeline/TokensRegexNERAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/TokensRegexNERAnnotator.java
@@ -151,6 +151,7 @@ public class TokensRegexNERAnnotator implements Annotator  {
   private final Set<String> myLabels;  // set of labels to always overwrite
   private final Pattern validPosPattern;
   private final List<Pattern> validPosPatternList;
+  private final List<String[]> headerList;
   private final boolean verbose;
 
   private final Map<Entry, Integer> entryToMappingFileNumber;
@@ -247,10 +248,22 @@ public class TokensRegexNERAnnotator implements Annotator  {
     String[] annotationFieldnames = null;
     String[] headerFields = null;
     if (readHeaderFromFile) {
-      // Get header as first line from all files...
-      // TODO: support reading header from file
-      throw new UnsupportedOperationException("Reading header from file not yet supported!!!");
-    } else {
+		annotationFieldnames = new String[0]; 	
+		annotationFields = new ArrayList<>();
+    		//Set the read header property of each file to true
+    		for (int i = 0; i < mappings.length; i++) {
+    			String mappingLine = mappings[i];
+    			if (!mappingLine.contains("header")) {
+    				mappingLine = "header=true, "+ mappingLine;
+    				mappings[i] = mappingLine;
+    			}
+    			else if (!mappingLine.toLowerCase().matches("header\\s*=\\s*true")){
+    				throw new Error("Error! The annotator header property is set to true, but a different options has been provided for mapping file: " + mappingLine);
+    			}
+    			
+    		}
+   		
+    } else	{
       headerFields = COMMA_DELIMITERS_PATTERN.split(headerProp);
       // Take header fields and remove known headers to get annotation field names
       List<String> fieldNames = new ArrayList<>();
@@ -271,6 +284,7 @@ public class TokensRegexNERAnnotator implements Annotator  {
           }
         }
       }
+      
       annotationFieldnames = new String[fieldNames.size()];
       fieldNames.toArray(annotationFieldnames);
       annotationFields = fieldClasses;
@@ -288,9 +302,10 @@ public class TokensRegexNERAnnotator implements Annotator  {
     }
     validPosPatternList = new ArrayList<>();
     ignoreCaseList = new ArrayList<>();
+    headerList = new ArrayList<>();
     entryToMappingFileNumber = new HashMap<>();
-    processPerFileOptions(name, mappings, ignoreCaseList, validPosPatternList, ignoreCase, validPosPattern);
-    entries = Collections.unmodifiableList(readEntries(name, noDefaultOverwriteLabels, ignoreCaseList, entryToMappingFileNumber, verbose, headerFields, annotationFieldnames, mappings));
+    annotationFieldnames = processPerFileOptions(name, mappings, ignoreCaseList, validPosPatternList, headerList, ignoreCase, validPosPattern, headerFields, annotationFieldnames, annotationFields);
+    entries = Collections.unmodifiableList(readEntries(name, noDefaultOverwriteLabels, ignoreCaseList, headerList, entryToMappingFileNumber, verbose, annotationFieldnames, mappings));
     IdentityHashMap<SequencePattern<CoreMap>, Entry> patternToEntry = new IdentityHashMap<>();
     multiPatternMatcher = createPatternMatcher(patternToEntry);
     this.patternToEntry = Collections.unmodifiableMap(patternToEntry);
@@ -572,7 +587,8 @@ public class TokensRegexNERAnnotator implements Annotator  {
    */
   private static List<Entry> readEntries(String annotatorName,
                                          Set<String> noDefaultOverwriteLabels,
-                                         List<Boolean> ignoreCaseList, Map<Entry, Integer> entryToMappingFileNumber, boolean verbose,
+                                         List<Boolean> ignoreCaseList, List<String[]> headerList,
+                                         Map<Entry, Integer> entryToMappingFileNumber, boolean verbose,
                                          String[] headerFields,
                                          String[] annotationFieldnames,
                                          String... mappings) {
@@ -588,7 +604,7 @@ public class TokensRegexNERAnnotator implements Annotator  {
       BufferedReader rd = null;
       try {
         rd = IOUtils.readerFromString(mapping);
-        readEntries(annotatorName, headerFields, annotationFieldnames, entries, seenRegexes, mapping, rd, noDefaultOverwriteLabels, ignoreCaseList.get(mappingFileIndex), mappingFileIndex, entryToMappingFileNumber, verbose);
+        readEntries(annotatorName, headerList.get(mappingFileIndex), annotationFieldnames, entries, seenRegexes, mapping, rd, noDefaultOverwriteLabels, ignoreCaseList.get(mappingFileIndex), mappingFileIndex, entryToMappingFileNumber, verbose);
       } catch (IOException e) {
         throw new RuntimeIOException("Couldn't read TokensRegexNER from " + mapping, e);
       } finally {
@@ -670,6 +686,24 @@ public class TokensRegexNERAnnotator implements Annotator  {
     for (String line; (line = mapping.readLine()) != null; ) {
       lineCount ++;
       String[] split = line.split("\t");
+      
+      if (lineCount == 1) {
+  	  	if (split.length == headerFields.length) {
+  	  		boolean equals = true;
+  	  		for (int i = 0; i < split.length; i ++) {
+  	  			if (!Objects.equals(split[i], headerFields[i])) {
+  	  				equals = false;
+  	  				break;
+  	  			}
+  	  		}
+  	  		if (equals) {
+  	  	  		//This is the header line -> skip
+  	  	  		continue;
+  	  		}	
+  	  	}
+      }
+      
+      
       if (split.length < minLength || split.length > maxLength) {
         String err = "many";
         if (split.length < minLength) {
@@ -818,14 +852,15 @@ public class TokensRegexNERAnnotator implements Annotator  {
       return SEMICOLON_DELIMITERS_PATTERN.split(mappingFiles);
     }
   }
-
-  private static void processPerFileOptions(String annotatorName, String[] mappings, List<Boolean> ignoreCaseList, List<Pattern> validPosPatternList, boolean ignoreCase, Pattern validPosPattern) {
+  private static String[] processPerFileOptions(String annotatorName, String[] mappings, List<Boolean> ignoreCaseList, List<Pattern> validPosPatternList, List<String[]> filesHeaderList, boolean ignoreCase, Pattern validPosPattern, String[] headerList, String[] annotationFieldnames, List<Class> annotationFields) {
     Integer numMappingFiles = mappings.length;
     for (int index = 0; index < numMappingFiles; index++) {
       boolean ignoreCaseSet = false;
       boolean validPosPatternSet = false;
+      boolean headerSet = false;
       String[] allOptions = COMMA_DELIMITERS_PATTERN.split(mappings[index].trim());
       Integer numOptions = allOptions.length;
+      String filePath = allOptions[allOptions.length - 1];
       if (numOptions > 1) { // there are some per file options here
         for (int i = 0; i < numOptions-1; i++) {
           String[] optionAndValue = EQUALS_DELIMITERS_PATTERN.split(allOptions[i].trim());
@@ -847,6 +882,39 @@ public class TokensRegexNERAnnotator implements Annotator  {
                 }
                 validPosPatternSet = true;
                 break;
+              case "header":
+          	  	String headerItems = optionAndValue[1].trim();
+          	  	String[] thisFileheaderList = COMMA_DELIMITERS_PATTERN.split(headerItems);
+          	  	headerSet = true;
+          	  	
+          	  	if (thisFileheaderList.length == 1 && thisFileheaderList[0].equalsIgnoreCase("true")) {
+          	  		try {
+          	  				BufferedReader br = IOUtils.readerFromString(filePath);
+							String headerLine = br.readLine();
+							IOUtils.closeIgnoringExceptions(br);
+							thisFileheaderList = headerLine.split("\\t");
+						} catch (IOException e) {
+							e.printStackTrace();
+						}
+          	  	}
+          	  	            	  	
+          	  	filesHeaderList.add(thisFileheaderList);
+          	  	
+	        	      for (String field : thisFileheaderList) {
+	        	          if (!predefinedHeaderFields.contains(field) && !Arrays.asList(annotationFieldnames).contains(field)) {
+	        	              Class fieldClass = EnvLookup.lookupAnnotationKeyWithClassname(null, field);
+	        	              if (fieldClass == null) {
+		            	        throw new RuntimeException( "Not recognized annotation class field \"" + field + "\" in header for mapping file " + allOptions[numOptions -1]);
+	        	              }
+	        	              else {
+	        	            	  annotationFields.add(fieldClass);
+	        	            	  annotationFieldnames = Arrays.copyOf(annotationFieldnames, annotationFieldnames.length + 1);
+	        	            	  annotationFieldnames[annotationFieldnames.length - 1] = field;
+	        	              }
+	        	          }
+	        	      }
+	        	      break;
+	        	      
               default:
                 break;
             }
@@ -862,7 +930,14 @@ public class TokensRegexNERAnnotator implements Annotator  {
       if (!validPosPatternSet) {
         validPosPatternList.add(validPosPattern);
       }
+      
+      if (!headerSet) {
+  	  	filesHeaderList.add(headerList);
+      }
     }
+    
+    return annotationFieldnames;
+
   }
 
   private static boolean atLeastOneValidPosPattern(List<Pattern> validPosPatternList) {


### PR DESCRIPTION
It is possible to specify a different header for each mapping file: it is handled as other fields by the processPerFileOptions method at line [885](https://github.com/alsora/CoreNLP/blob/master/src/edu/stanford/nlp/pipeline/TokensRegexNERAnnotator.java#L885).

Here is an example of mapping files with header declaration:

`properties.setProperty("ner.fine.regexner.mapping", 
"ignorecase=true, header=pattern overwrite priority, file1.tab;" +
"ignorecase=true, file2.tab");
`

The header items are whitespace separated and can also be specified for one of the files.

Files MUST be separated with semi column.

In the same way, it is possible to fetch the header from the first line of a specific file.

`properties.setProperty("ner.fine.regexner.mapping", 
"ignorecase=true, header=true, file1.tab;" +
"ignorecase=true, header=pattern overwrite priority group, file2.tab");
`

When reading entries from a file a check is present in order to discard the first line if it's the header (line [690](https://github.com/alsora/CoreNLP/blob/master/src/edu/stanford/nlp/pipeline/TokensRegexNERAnnotator.java#L690)).

Then it has been implemented the possibility of setting  "ner.fine.regexner.mapping.header=true" in line [250](https://github.com/alsora/CoreNLP/blob/master/src/edu/stanford/nlp/pipeline/TokensRegexNERAnnotator.java#L250).
This has the same effect of writing "header=true" for each provided mapping file.