### PR TITLE
Sentiment Pipeline: Disable builgraphs for parser

### DIFF
--- a/src/edu/stanford/nlp/sentiment/SentimentPipeline.java
+++ b/src/edu/stanford/nlp/sentiment/SentimentPipeline.java
@@ -320,6 +320,7 @@ public class SentimentPipeline  {
     } else {
       pipelineProps.setProperty("annotators", "parse, sentiment");
       pipelineProps.setProperty("parse.binaryTrees", "true");
+      pipelineProps.setProperty("parse.buildgraphs", "false"); 
       pipelineProps.setProperty("enforceRequirements", "false");
       tokenizerProps = new Properties();
       tokenizerProps.setProperty("annotators", "tokenize, ssplit");


### PR DESCRIPTION
Optimization: Set `parse.buildgraphs` to `false` for not building Enhanced Deps (enhancedDeps, enhanced++Deps) as it is not utilized by Sentiment Pipeline internally.

**Benefits**

- Functionally optimized as extra Dependencies are not generated by the Parser

- Lightweight response body while using Sentiment Annotator via CoreNLPServer 

- Modular code change (only in SentimentPipeline.java) and thus Parser  behavior is not impacted for all Pipelines but Sentiment.