### PR TITLE
Fix percent runs

### DIFF
--- a/itest/src/edu/stanford/nlp/pipeline/EntityMentionsAnnotatorITest.java
+++ b/itest/src/edu/stanford/nlp/pipeline/EntityMentionsAnnotatorITest.java
@@ -131,6 +131,19 @@ public class EntityMentionsAnnotatorITest extends TestCase {
     compareMentions("testNumbers", expectedMentions, mentions);
   }
 
+  public void testPercent() {
+    Annotation doc = createDocument("12% 13%");
+    EntityMentionsAnnotator annotator = getMentionsAnnotator();
+
+    annotator.annotate(doc);
+    List<CoreMap> mentions = doc.get(CoreAnnotations.MentionsAnnotation.class);
+    String[] expectedMentions = {
+        "[Text=12% CharacterOffsetBegin=0 CharacterOffsetEnd=3 Tokens=[12-1, %-2] TokenBegin=0 TokenEnd=2 NamedEntityTag=PERCENT NormalizedNamedEntityTag=%12.0 EntityType=PERCENT SentenceIndex=0 EntityMentionIndex=0 CanonicalEntityMentionIndex=0]",
+        "[Text=13% CharacterOffsetBegin=4 CharacterOffsetEnd=7 Tokens=[13-3, %-4] TokenBegin=2 TokenEnd=4 NamedEntityTag=PERCENT NormalizedNamedEntityTag=%13.0 EntityType=PERCENT SentenceIndex=0 EntityMentionIndex=1 CanonicalEntityMentionIndex=1]"
+    };
+    compareMentions("testPercent", expectedMentions, mentions);
+  }
+
   public void testNewsText() {
     Annotation doc = createDocument("Duke of Cambridge, Prince William, unveiled a new China Center in the University of Oxford Monday.\n" +
         "Covering an area nearly 5,500 square meters, the new Dickson Poon University of Oxford China Center in St Hugh's College cost about 21 million pounds.\n" +

--- a/src/edu/stanford/nlp/ie/QuantifiableEntityNormalizer.java
+++ b/src/edu/stanford/nlp/ie/QuantifiableEntityNormalizer.java
@@ -1295,10 +1295,14 @@ public class QuantifiableEntityNormalizer  {
   }
 
   public static <E extends CoreMap> boolean isCompatible(String tag, E prev, E cur) {
-    if ("NUMBER".equals(tag) || "ORDINAL".equals(tag)) {
+    if ("NUMBER".equals(tag) || "ORDINAL".equals(tag) || "PERCENT".equals(tag)) {
       // Get NumericCompositeValueAnnotation and say two entities are incompatible if they are different
       Number n1 = cur.get(CoreAnnotations.NumericCompositeValueAnnotation.class);
       Number n2 = prev.get(CoreAnnotations.NumericCompositeValueAnnotation.class);
+
+      // Special case for % sign
+      if ("PERCENT".equals(tag) && n1 == null) return true;
+
       boolean compatible = checkNumbers(n1,n2);
       if (!compatible) return false;
     }


### PR DESCRIPTION
This fixes an issue where consecutive PERCENT tokens e.g. "12% 13%" get collapsed into a single entity mention. There's a similar problem with MONEY which I hope to tackle in due course.