### PR TITLE
Interpret maxTime of 0 as no timeout

### DIFF
--- a/src/edu/stanford/nlp/util/concurrent/InterruptibleMulticoreWrapper.java
+++ b/src/edu/stanford/nlp/util/concurrent/InterruptibleMulticoreWrapper.java
@@ -28,7 +28,7 @@ public class InterruptibleMulticoreWrapper<I,O> extends MulticoreWrapper<I,O> {
   @Override
   protected Integer getProcessor() {
     try {
-      return (timeout < 0) ? idleProcessors.take() : idleProcessors.poll(timeout, TimeUnit.MILLISECONDS);
+      return (timeout <= 0) ? idleProcessors.take() : idleProcessors.poll(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       throw new RuntimeInterruptedException(e);
     }


### PR DESCRIPTION
NERCombinerAnnotator defaults maxTime to 0, and so behaves
non-deterministically if nThreads > 1.

SentenceAnnotator also treats zero as though it means no timeout.