### PR TITLE
make sure maxIterations is used

### DIFF
--- a/src/edu/stanford/nlp/ie/crf/CRFClassifier.java
+++ b/src/edu/stanford/nlp/ie/crf/CRFClassifier.java
@@ -1932,7 +1932,7 @@ public class CRFClassifier<IN extends CoreMap> extends AbstractSequenceClassifie
         throw new RuntimeException("gradient check failed");
       }
     }
-    return minimizer.minimize(func, flags.tolerance, initialWeights);
+    return minimizer.minimize(func, flags.tolerance, initialWeights, flags.maxIterations);
   }
 
   public Minimizer<DiffFunction> getMinimizer() {


### PR DESCRIPTION
Currently to limit the number of iterations, only tolerance can be used. There's another parameter maxIterations, which is ignored. This PR would mean that maxIterations actually gets used.
