### PR TITLE
Add minimal root checks to prevent runtime exception

### DIFF
--- a/src/edu/stanford/nlp/trees/UniversalEnglishGrammaticalStructure.java
+++ b/src/edu/stanford/nlp/trees/UniversalEnglishGrammaticalStructure.java
@@ -1724,6 +1724,11 @@ public class UniversalEnglishGrammaticalStructure extends GrammaticalStructure  
 
 
   private static void demoteQuantificationalModifiers(SemanticGraph sg) {
+	  
+    /* Semgrexes require a graph with a root. */
+    if (sg.getRoots().isEmpty())
+	  return;
+    
     SemanticGraph sgCopy = sg.makeSoftCopy();
     SemgrexMatcher matcher = QUANT_MOD_3W_PATTERN.matcher(sgCopy);
 
@@ -1811,6 +1816,10 @@ public class UniversalEnglishGrammaticalStructure extends GrammaticalStructure  
     if ( ! USE_NAME) {
       return;
     }
+    
+    /* Semgrexes require a graph with a root. */
+    if (sg.getRoots().isEmpty())
+	  return;
 
     // check whether NER tags are available
     IndexedWord rootToken = sg.getFirstRoot();


### PR DESCRIPTION
Other methods in the UniversalEnglishGrammaticalStructure class check if the SemanticGraph variable has roots before executing Semgrex Pattern matching and does nothing if there are no roots; the Semgrex Pattern requires that graphs have a root to operate. 
Current code for 5 methods are missing these guard statements, only 2 have been fixed as they are not proceeded by checks in other methods calling them.