### PR TITLE
Fix quoteattribution properties

### DIFF
--- a/src/edu/stanford/nlp/pipeline/AnnotatorImplementations.java
+++ b/src/edu/stanford/nlp/pipeline/AnnotatorImplementations.java
@@ -262,8 +262,14 @@ public class AnnotatorImplementations  {
    * Annotate quotes and extract them like sentences
    */
   public Annotator quote(Properties properties) {
-    Properties relevantProperties = PropertiesUtils.extractPrefixedProperties(properties,
-        Annotator.STANFORD_QUOTE + '.');
+	Properties relevantProperties = PropertiesUtils.extractPrefixedProperties(properties,
+	    Annotator.STANFORD_QUOTE + '.');
+	Properties depparseProperties = PropertiesUtils.extractPrefixedProperties(properties,
+	    Annotator.STANFORD_DEPENDENCIES + '.');
+	for (String key: depparseProperties.stringPropertyNames())  {
+	    relevantProperties.setProperty("attribution." + Annotator.STANFORD_DEPENDENCIES + '.' + key, 
+		depparseProperties.getProperty(key));
+		}
     return new QuoteAnnotator(relevantProperties);
   }
 

--- a/src/edu/stanford/nlp/pipeline/QuoteAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/QuoteAnnotator.java
@@ -7,10 +7,12 @@ import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.util.CoreMap;
 import edu.stanford.nlp.util.Generics;
 import edu.stanford.nlp.util.Pair;
+import edu.stanford.nlp.util.PropertiesUtils;
 import edu.stanford.nlp.util.Timing;
 import edu.stanford.nlp.util.logging.Redwood;
 
 import java.util.*;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -167,9 +169,11 @@ public class QuoteAnnotator implements Annotator  {
       timer = new Timing();
       log.info("Preparing quote annotator...");
     }
-    if (ATTRIBUTE_QUOTES)
-      quoteAttributionAnnotator = new QuoteAttributionAnnotator(props);
-
+    if (ATTRIBUTE_QUOTES)  {
+      Properties relevantProperties = PropertiesUtils.extractPrefixedProperties(props,
+        "attribution.");
+      quoteAttributionAnnotator = new QuoteAttributionAnnotator(relevantProperties);
+    }
     if (VERBOSE) {
       timer.stop("done.");
     }

--- a/src/edu/stanford/nlp/pipeline/QuoteAttributionAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/QuoteAttributionAnnotator.java
@@ -40,19 +40,19 @@ import java.util.*;
  *
  * The annotator has the following options:
  * <ul>
- *   <li>quoteattribution.charactersPath (required): path to file containing the character names, aliases,
+ *   <li>quote.attribution.charactersPath (required): path to file containing the character names, aliases,
  *   and gender information.</li>
- *   <li>quoteattribution.booknlpCoref (required): path to tokens file generated from
+ *   <li>quote.attribution.booknlpCoref (required): path to tokens file generated from
  *   <a href="https://github.com/dbamman/book-nlp">book-nlp</a> containing coref information.</li>
- *   <li>quoteattribution.QMSieves: list of sieves to use in the quote to mention linking phase
+ *   <li>quote.attribution.QMSieves: list of sieves to use in the quote to mention linking phase
  *   (default=tri,dep,onename,voc,paraend,conv,sup,loose). More information about the sieves can be found at our
  *   <a href="stanfordnlp.github.io/CoreNLP/quoteattribution.html">website</a>. </li>
- *   <li>quoteattribution.MSSieves: list of sieves to use in the mention to speaker linking phase
+ *   <li>quote.attribution.MSSieves: list of sieves to use in the mention to speaker linking phase
  *   (default=det,top).</li>
- *   <li>quoteattribution.model: path to trained model file.</li>
- *   <li>quoteattribution.familyWordsFile: path to file with family words list.</li>
- *   <li>quoteattribution.animacyWordsFile: path to file with animacy words list.</li>
- *   <li>quoteattribution.genderNamesFile: path to file with names list with gender information.</li>
+ *   <li>quote.attribution.model: path to trained model file.</li>
+ *   <li>quote.attribution.familyWordsFile: path to file with family words list.</li>
+ *   <li>quote.attribution.animacyWordsFile: path to file with animacy words list.</li>
+ *   <li>quote.attribution.genderNamesFile: path to file with names list with gender information.</li>
  * </ul>
  *
  * @author Grace Muzny, Michael Fang

--- a/src/edu/stanford/nlp/pipeline/QuoteAttributionAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/QuoteAttributionAnnotator.java
@@ -6,6 +6,7 @@ import edu.stanford.nlp.ling.CoreAnnotation;
 import edu.stanford.nlp.ling.CoreAnnotations;
 import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.paragraphs.ParagraphAnnotator;
+import edu.stanford.nlp.parser.nndep.DependencyParser;
 import edu.stanford.nlp.quoteattribution.ChapterAnnotator;
 import edu.stanford.nlp.quoteattribution.Person;
 import edu.stanford.nlp.quoteattribution.QuoteAttributionUtils;
@@ -148,6 +149,7 @@ public class QuoteAttributionAnnotator implements Annotator {
   private Map<String, List<Person>> characterMap;
   private String qmSieveList;
   private String msSieveList;
+  private DependencyParser parser;
 
   public QuoteAttributionAnnotator(Properties props) {
 
@@ -185,6 +187,15 @@ public class QuoteAttributionAnnotator implements Annotator {
     }
     // use Stanford CoreNLP coref to map mentions to canonical mentions
     useCoref = PropertiesUtils.getBool(props, "useCoref", useCoref);
+    
+    // setup dependency parser 
+    String DEPENDENCY_PARSER_MODEL = props.getProperty("depparse.model", 
+        DependencyParser.DEFAULT_MODEL);
+    Properties depparseProperties = PropertiesUtils.extractPrefixedProperties(props,
+        Annotator.STANFORD_DEPENDENCIES + '.');
+	parser = DependencyParser.loadFromModelFile(DEPENDENCY_PARSER_MODEL, 
+        depparseProperties);
+    
     if (VERBOSE) {
       timer.stop("done.");
     }
@@ -227,9 +238,9 @@ public class QuoteAttributionAnnotator implements Annotator {
     //annotate chapter numbers in sentences. Useful for denoting chapter boundaries
     new ChapterAnnotator().annotate(annotation);
     // to incorporate sentences across paragraphs
-    QuoteAttributionUtils.addEnhancedSentences(annotation);
+    QuoteAttributionUtils.addEnhancedSentences(annotation, parser);
     //annotate depparse of quote-removed sentences
-    QuoteAttributionUtils.annotateForDependencyParse(annotation);
+    QuoteAttributionUtils.annotateForDependencyParse(annotation, parser);
     Annotation preprocessed = annotation;
 
     // 2. Quote->Mention annotation

--- a/src/edu/stanford/nlp/pipeline/QuoteAttributionAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/QuoteAttributionAnnotator.java
@@ -131,9 +131,9 @@ public class QuoteAttributionAnnotator implements Annotator {
   public static final String DEFAULT_MODEL_PATH = "edu/stanford/nlp/models/quoteattribution/quoteattribution_model.ser";
 
   // these paths go in the props file
-  public static String FAMILY_WORD_LIST = "edu/stanford/nlp/models/quoteattribution/family_words.txt";
-  public static String ANIMACY_WORD_LIST = "edu/stanford/nlp/models/quoteattribution/animate.unigrams.txt";
-  public static String GENDER_WORD_LIST = "edu/stanford/nlp/models/quoteattribution/gender_filtered.txt";
+  public static String FAMILY_WORD_LIST = "edu/stanford/nlp/quoteattribution/family_words.txt";
+  public static String ANIMACY_WORD_LIST = "edu/stanford/nlp/quoteattribution/animate.unigrams.txt";
+  public static String GENDER_WORD_LIST = "edu/stanford/nlp/quoteattribution/gender_filtered.txt";
   public static String COREF_PATH = "";
   public static String MODEL_PATH = "edu/stanford/nlp/models/quoteattribution/quoteattribution_model.ser";
   public static String CHARACTERS_FILE = "";


### PR DESCRIPTION
Patch to fix problem with QuoteAttributionAnnotator not using properties correctly.  The default locations get used and any custom properties for quote.attribution.* and depparse.* are currently ignored.   

The fix
- passes through relevant properties (quote.*, depparse.*) to QuoteAnnotator so that it can configure QuoteAttributionAnnotator correctly
- updates doc to reflect property quoteattribution is actually quote.attribution (to fulfill passthrough on quote.*)
- updated QuoteAttributionUtil so that it uses the properties passed through for depparse.* and creates a DependencyParser based on those properties instead of default only. 

I tested this locally with the default properties and file locations, as well as a test that manually loaded the files from /tmp/edu/*  (ex. properties.put("quote.attribution.familyWordsFile", "/tmp/edu/stanford/nlp/quoteattribution/family_words.txt");

This pull request is related to the discussion in https://github.com/stanfordnlp/CoreNLP/issues/799 which I joined because it was similar to my problem.  OP problem ultimately had a different source, but I wrote this fix to solve my problem.   My original problem was that I couldn't use quote attribution if my model files weren't in the classpath because the paths in properties weren't getting used.  

I declare this contribution in the public domain.