### PR TITLE
Rejuvenate log levels

### DIFF
--- a/src/edu/stanford/nlp/dcoref/ACEMentionExtractor.java
+++ b/src/edu/stanford/nlp/dcoref/ACEMentionExtractor.java
@@ -262,8 +262,8 @@ public class ACEMentionExtractor extends MentionExtractor {
       sent += "\n";
       doc.append(sent);
     }
-    if (gold) logger.fine("New DOC: (GOLD MENTIONS) ==================================================");
-    else logger.fine("New DOC: (Predicted Mentions) ==================================================");
-    logger.fine(doc.toString());
+    if (gold) logger.finest("New DOC: (GOLD MENTIONS) ==================================================");
+    else logger.finest("New DOC: (Predicted Mentions) ==================================================");
+    logger.finest(doc.toString());
   }
 }

--- a/src/edu/stanford/nlp/dcoref/CoNLL2011DocumentReader.java
+++ b/src/edu/stanford/nlp/dcoref/CoNLL2011DocumentReader.java
@@ -90,7 +90,7 @@ public class CoNLL2011DocumentReader  {
       Collections.sort(this.fileList);
     }
     curFileIndex = 0;
-    logger.info("Reading " + fileList.size() + " CoNll2011 files from " + filepath);
+    logger.finest("Reading " + fileList.size() + " CoNll2011 files from " + filepath);
   }
 
   private static List<File> getFiles(String filepath, Pattern filter)
@@ -121,7 +121,7 @@ public class CoNLL2011DocumentReader  {
         docIterator = new DocumentIterator(curFile.getAbsolutePath(), options);
       }
       while ( ! docIterator.hasNext()) {
-        logger.info("Processed " + docIterator.docCnt + " documents in " + curFile.getAbsolutePath());
+        logger.finest("Processed " + docIterator.docCnt + " documents in " + curFile.getAbsolutePath());
         docIterator.close();
         curFileIndex++;
         if (curFileIndex >= fileList.size()) {
@@ -131,7 +131,7 @@ public class CoNLL2011DocumentReader  {
         docIterator = new DocumentIterator(curFile.getAbsolutePath(), options);
       }
       Document next = docIterator.next();
-      SieveCoreferenceSystem.logger.fine("Reading document: " + next.getDocumentID());
+      SieveCoreferenceSystem.logger.finest("Reading document: " + next.getDocumentID());
       return next;
     } catch (IOException ex) {
       throw new RuntimeIOException(ex);
@@ -858,8 +858,8 @@ public class CoNLL2011DocumentReader  {
             if (span.getSource() == tokenStart && span.getTarget() == tokenEnd - 1) {
               mentionExactTreeSpan++;
             } else {
-              logger.info("Tree span is " + span + ", tree node is " + t);
-              logger.info("Mention span is " + tokenStart + " " + (tokenEnd - 1) + ", mention is " + m);
+              logger.finest("Tree span is " + span + ", tree node is " + t);
+              logger.finest("Mention span is " + tokenStart + " " + (tokenEnd - 1) + ", mention is " + m);
             }
           } else {
             logger.warning("No span for " + t);
@@ -870,15 +870,15 @@ public class CoNLL2011DocumentReader  {
             npt2 = npt;
           } else {
             mentionTreePretermNonPretermNoMatchLabelCounter.incrementCount(t.label().value());
-            logger.info("NPT: Tree span is " + span + ", tree node is " + npt);
-            logger.info("NPT: Mention span is " + tokenStart + " " + (tokenEnd - 1) + ", mention is " + m);
+            logger.finest("NPT: Tree span is " + span + ", tree node is " + npt);
+            logger.finest("NPT: Mention span is " + tokenStart + " " + (tokenEnd - 1) + ", mention is " + m);
             Label tlabel = t.label();
             if (tlabel instanceof CoreLabel) {
               CoreMap mention = ((CoreLabel) tlabel).get(CorefMentionAnnotation.class);
               String corefClusterId = mention.get(CorefCoreAnnotations.CorefAnnotation.class);
               Collection<CoreMap> clusteredMentions = doc.corefChainMap.get(corefClusterId);
               for (CoreMap m2:clusteredMentions) {
-                logger.info("NPT: Clustered mention " + m2.get(CoreAnnotations.TextAnnotation.class));
+                logger.finest("NPT: Clustered mention " + m2.get(CoreAnnotations.TextAnnotation.class));
               }
             }
 
@@ -899,10 +899,10 @@ public class CoNLL2011DocumentReader  {
                 Label plabel = parent.label();
                 if (plabel instanceof CoreLabel) {
                   if (((CoreLabel) plabel).containsKey(NamedEntityAnnotation.class)) {
-                    logger.info("NER Mention: " + m);
+                    logger.finest("NER Mention: " + m);
                     CoreMap parentNerChunk = ((CoreLabel) plabel).get(NamedEntityAnnotation.class);
-                    logger.info("Nested inside NER Mention: " + parentNerChunk);
-                    logger.info("Nested inside NER Mention parent node: " + parent);
+                    logger.finest("Nested inside NER Mention: " + parentNerChunk);
+                    logger.finest("Nested inside NER Mention parent node: " + parent);
                     nestedNerMentions++;
                     break;
                   }
@@ -971,7 +971,7 @@ public class CoNLL2011DocumentReader  {
       System.exit(-1);
     }
     PrintWriter fout = new PrintWriter(outfile);
-    logger.info("Writing to " + outfile);
+    logger.finest("Writing to " + outfile);
     String ext = props.getProperty("ext");
     Options options;
     if (ext != null) {

--- a/src/edu/stanford/nlp/dcoref/CoNLLMentionExtractor.java
+++ b/src/edu/stanford/nlp/dcoref/CoNLLMentionExtractor.java
@@ -206,12 +206,12 @@ public class CoNLLMentionExtractor extends MentionExtractor {
       List<Pair<Integer,Integer>> goldMentionsSpans = extractSpans(goldMentionsSent);
 
       for (Pair<Integer,Integer> mentionSpan: goldMentionsSpans){
-        logger.finer("RECALL ERROR\n");
-        logger.finer(coreMap + "\n");
+        logger.finest("RECALL ERROR\n");
+        logger.finest(coreMap + "\n");
         for (int x=mentionSpan.first;x<mentionSpan.second;x++){
-          logger.finer(words.get(x).value() + " ");
+          logger.finest(words.get(x).value() + " ");
         }
-        logger.finer("\n"+tree + "\n");
+        logger.finest("\n"+tree + "\n");
       }
     }
   }

--- a/src/edu/stanford/nlp/dcoref/Constants.java
+++ b/src/edu/stanford/nlp/dcoref/Constants.java
@@ -121,35 +121,35 @@ public class Constants {
 
   /** print the values of variables in this class */
   public static void printConstants(Logger logger) {
-    if (Constants.USE_ANIMACY_LIST) logger.info("USE_ANIMACY_LIST on");
-    else logger.info("USE_ANIMACY_LIST off");
-    if (Constants.USE_ANIMACY_LIST) logger.info("USE_ANIMACY_LIST on");
-    else logger.info("USE_ANIMACY_LIST off");
-    if (Constants.USE_DISCOURSE_SALIENCE) logger.info("use discourse salience");
-    else logger.info("not use discourse salience");
-    if (Constants.USE_TRUECASE) logger.info("use truecase annotator");
-    else logger.info("not use truecase annotator");
-    if (Constants.USE_DISCOURSE_CONSTRAINTS) logger.info("USE_DISCOURSE_CONSTRAINTS on");
-    else logger.info("USE_DISCOURSE_CONSTRAINTS off");
-    if (Constants.USE_GOLD_POS) logger.info("USE_GOLD_POS on");
-    else logger.info("USE_GOLD_POS off");
-    if (Constants.USE_GOLD_NE) logger.info("use gold NE type annotation");
-    else logger.info("use Stanford NER");
-    if (Constants.USE_GOLD_PARSES) logger.info("USE_GOLD_PARSES on");
-    else logger.info("USE_GOLD_PARSES off");
-    if (Constants.USE_GOLD_SPEAKER_TAGS) logger.info("USE_GOLD_SPEAKER_TAGS on");
-    else logger.info("USE_GOLD_SPEAKER_TAGS off");
-    if (Constants.USE_GOLD_MENTIONS) logger.info("USE_GOLD_MENTIONS on");
-    else logger.info("USE_GOLD_MENTIONS off");
-    if (Constants.USE_GOLD_MENTION_BOUNDARIES) logger.info("USE_GOLD_MENTION_BOUNDARIES on");
-    else logger.info("USE_GOLD_MENTION_BOUNDARIES off");
-    if (Constants.USE_CONLL_AUTO) logger.info("use conll auto set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use auto");
-    else logger.info("use conll gold set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use gold");
-    if (Constants.REMOVE_SINGLETONS) logger.info("REMOVE_SINGLETONS on");
-    else logger.info("REMOVE_SINGLETONS off");
-    if (Constants.REMOVE_APPOSITION_PREDICATENOMINATIVES) logger.info("REMOVE_APPOSITION_PREDICATENOMINATIVES on");
-    else logger.info("REMOVE_APPOSITION_PREDICATENOMINATIVES off");
-    logger.info("=================================================================");
+    if (Constants.USE_ANIMACY_LIST) logger.finest("USE_ANIMACY_LIST on");
+    else logger.finest("USE_ANIMACY_LIST off");
+    if (Constants.USE_ANIMACY_LIST) logger.finest("USE_ANIMACY_LIST on");
+    else logger.finest("USE_ANIMACY_LIST off");
+    if (Constants.USE_DISCOURSE_SALIENCE) logger.finest("use discourse salience");
+    else logger.finest("not use discourse salience");
+    if (Constants.USE_TRUECASE) logger.finest("use truecase annotator");
+    else logger.finest("not use truecase annotator");
+    if (Constants.USE_DISCOURSE_CONSTRAINTS) logger.finest("USE_DISCOURSE_CONSTRAINTS on");
+    else logger.finest("USE_DISCOURSE_CONSTRAINTS off");
+    if (Constants.USE_GOLD_POS) logger.finest("USE_GOLD_POS on");
+    else logger.finest("USE_GOLD_POS off");
+    if (Constants.USE_GOLD_NE) logger.finest("use gold NE type annotation");
+    else logger.finest("use Stanford NER");
+    if (Constants.USE_GOLD_PARSES) logger.finest("USE_GOLD_PARSES on");
+    else logger.finest("USE_GOLD_PARSES off");
+    if (Constants.USE_GOLD_SPEAKER_TAGS) logger.finest("USE_GOLD_SPEAKER_TAGS on");
+    else logger.finest("USE_GOLD_SPEAKER_TAGS off");
+    if (Constants.USE_GOLD_MENTIONS) logger.finest("USE_GOLD_MENTIONS on");
+    else logger.finest("USE_GOLD_MENTIONS off");
+    if (Constants.USE_GOLD_MENTION_BOUNDARIES) logger.finest("USE_GOLD_MENTION_BOUNDARIES on");
+    else logger.finest("USE_GOLD_MENTION_BOUNDARIES off");
+    if (Constants.USE_CONLL_AUTO) logger.finest("use conll auto set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use auto");
+    else logger.finest("use conll gold set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use gold");
+    if (Constants.REMOVE_SINGLETONS) logger.finest("REMOVE_SINGLETONS on");
+    else logger.finest("REMOVE_SINGLETONS off");
+    if (Constants.REMOVE_APPOSITION_PREDICATENOMINATIVES) logger.finest("REMOVE_APPOSITION_PREDICATENOMINATIVES on");
+    else logger.finest("REMOVE_APPOSITION_PREDICATENOMINATIVES off");
+    logger.finest("=================================================================");
   }
 
 }

--- a/src/edu/stanford/nlp/dcoref/CorefCluster.java
+++ b/src/edu/stanford/nlp/dcoref/CorefCluster.java
@@ -158,16 +158,16 @@ public class CorefCluster implements Serializable{
       to.firstMention = from.firstMention;
     }
     if(from.representative.moreRepresentativeThan(to.representative)) to.representative = from.representative;
-    SieveCoreferenceSystem.logger.finer("merged clusters: "+toID+" += "+from.clusterID);
+    SieveCoreferenceSystem.logger.finest("merged clusters: "+toID+" += "+from.clusterID);
     to.printCorefCluster(SieveCoreferenceSystem.logger);
     from.printCorefCluster(SieveCoreferenceSystem.logger);
-    SieveCoreferenceSystem.logger.finer("");
+    SieveCoreferenceSystem.logger.finest("");
   }
 
   /** Print cluster information */
   public void printCorefCluster(Logger logger){
-    logger.finer("Cluster ID: "+clusterID+"\tNumbers: "+numbers+"\tGenders: "+genders+"\tanimacies: "+animacies);
-    logger.finer("NE: "+nerStrings+"\tfirst Mention's ID: "+firstMention.mentionID+"\tHeads: "+heads+"\twords: "+words);
+    logger.finest("Cluster ID: "+clusterID+"\tNumbers: "+numbers+"\tGenders: "+genders+"\tanimacies: "+animacies);
+    logger.finest("NE: "+nerStrings+"\tfirst Mention's ID: "+firstMention.mentionID+"\tHeads: "+heads+"\twords: "+words);
     TreeMap<Integer, Mention> forSortedPrint = new TreeMap<>();
     for(Mention m : this.corefMentions){
       forSortedPrint.put(m.mentionID, m);
@@ -175,11 +175,11 @@ public class CorefCluster implements Serializable{
     for(Mention m : forSortedPrint.values()){
       String rep = (representative == m)? "*":"";
       if(m.goldCorefClusterID==-1){
-        logger.finer(rep + "mention-> id:"+m.mentionID+"\toriginalRef: "
+        logger.finest(rep + "mention-> id:"+m.mentionID+"\toriginalRef: "
                 +m.originalRef+"\t"+m.spanToString() +"\tsentNum: "+m.sentNum+"\tstartIndex: "
                 +m.startIndex+"\tType: "+m.mentionType+"\tNER: "+m.nerString);
       } else{
-        logger.finer(rep + "mention-> id:"+m.mentionID+"\toriginalClusterID: "
+        logger.finest(rep + "mention-> id:"+m.mentionID+"\toriginalClusterID: "
                 +m.goldCorefClusterID+"\t"+m.spanToString() +"\tsentNum: "+m.sentNum+"\tstartIndex: "
                 +m.startIndex +"\toriginalRef: "+m.originalRef+"\tType: "+m.mentionType+"\tNER: "+m.nerString);
       }

--- a/src/edu/stanford/nlp/dcoref/CorefScorer.java
+++ b/src/edu/stanford/nlp/dcoref/CorefScorer.java
@@ -81,14 +81,14 @@ public abstract class CorefScorer {
     if (printF1First) {
       String str = "F1 = "+F1+", P = "+P+" ("+(int) precisionNumSum+"/"+(int) precisionDenSum+"), R = "+R+" ("+(int) recallNumSum+"/"+(int) recallDenSum+")";
       if(scoreType == ScoreType.Pairwise){
-        logger.fine("Pairwise "+str);
+        logger.finest("Pairwise "+str);
       } else if(scoreType == ScoreType.BCubed){
-        logger.fine("B cubed  "+str);
+        logger.finest("B cubed  "+str);
       } else {
-        logger.fine("MUC      "+str);
+        logger.finest("MUC      "+str);
       }
     } else {
-      logger.fine("& "+PP+" & "+RR + " & "+F1F1);
+      logger.finest("& "+PP+" & "+RR + " & "+F1F1);
     }
   }
 

--- a/src/edu/stanford/nlp/dcoref/Document.java
+++ b/src/edu/stanford/nlp/dcoref/Document.java
@@ -860,8 +860,8 @@ public class Document implements Serializable {
     for(Mention g : allGoldMentions.values()) {
       if(!g.twinless) foundGoldCount++;
     }
-    SieveCoreferenceSystem.logger.fine("# of found gold mentions: "+foundGoldCount + " / # of gold mentions: "+allGoldMentions.size());
-    SieveCoreferenceSystem.logger.fine("gold mentions == ");
+    SieveCoreferenceSystem.logger.finest("# of found gold mentions: "+foundGoldCount + " / # of gold mentions: "+allGoldMentions.size());
+    SieveCoreferenceSystem.logger.finest("gold mentions == ");
   }
 
 }

--- a/src/edu/stanford/nlp/dcoref/Mention.java
+++ b/src/edu/stanford/nlp/dcoref/Mention.java
@@ -485,7 +485,7 @@ public class Mention implements CoreAnnotation<Mention>, Serializable {
   private void setType(Dictionaries dict) {
     if (isListLike()) {
       mentionType = MentionType.LIST;
-      SieveCoreferenceSystem.logger.finer("IS LIST: " + this);
+      SieveCoreferenceSystem.logger.finest("IS LIST: " + this);
     } else if (headWord.containsKey(CoreAnnotations.EntityTypeAnnotation.class)){    // ACE gold mention type
       if (headWord.get(CoreAnnotations.EntityTypeAnnotation.class).equals("PRO")) {
         mentionType = MentionType.PRONOMINAL;
@@ -514,7 +514,7 @@ public class Mention implements CoreAnnotation<Mention>, Serializable {
     gender = Gender.UNKNOWN;
     if(genderNumberResult!=null && this.number!=Number.PLURAL){
       gender = genderNumberResult;
-      SieveCoreferenceSystem.logger.finer("[Gender number count] New gender assigned:\t" + gender + ":\t" +  headString + "\tspan:" + spanToString());
+      SieveCoreferenceSystem.logger.finest("[Gender number count] New gender assigned:\t" + gender + ":\t" +  headString + "\tspan:" + spanToString());
     }
     if (mentionType == MentionType.PRONOMINAL) {
       if (dict.malePronouns.contains(headString)) {
@@ -533,27 +533,27 @@ public class Mention implements CoreAnnotation<Mention>, Serializable {
             String name = t.word().toLowerCase();
             if(dict.maleWords.contains(name)) {
               gender = Gender.MALE;
-              SieveCoreferenceSystem.logger.finer("[Bergsma List] New gender assigned:\tMale:\t" +  name + "\tspan:" + spanToString());
+              SieveCoreferenceSystem.logger.finest("[Bergsma List] New gender assigned:\tMale:\t" +  name + "\tspan:" + spanToString());
               break;
             }
             else if(dict.femaleWords.contains(name))  {
               gender = Gender.FEMALE;
-              SieveCoreferenceSystem.logger.finer("[Bergsma List] New gender assigned:\tFemale:\t" +  name + "\tspan:" + spanToString());
+              SieveCoreferenceSystem.logger.finest("[Bergsma List] New gender assigned:\tFemale:\t" +  name + "\tspan:" + spanToString());
               break;
             }
           }
         } else {
           if(dict.maleWords.contains(headString)) {
             gender = Gender.MALE;
-            SieveCoreferenceSystem.logger.finer("[Bergsma List] New gender assigned:\tMale:\t" +  headString + "\tspan:" + spanToString());
+            SieveCoreferenceSystem.logger.finest("[Bergsma List] New gender assigned:\tMale:\t" +  headString + "\tspan:" + spanToString());
           }
           else if(dict.femaleWords.contains(headString))  {
             gender = Gender.FEMALE;
-            SieveCoreferenceSystem.logger.finer("[Bergsma List] New gender assigned:\tFemale:\t" +  headString + "\tspan:" + spanToString());
+            SieveCoreferenceSystem.logger.finest("[Bergsma List] New gender assigned:\tFemale:\t" +  headString + "\tspan:" + spanToString());
           }
           else if(dict.neutralWords.contains(headString))   {
             gender = Gender.NEUTRAL;
-            SieveCoreferenceSystem.logger.finer("[Bergsma List] New gender assigned:\tNeutral:\t" +  headString + "\tspan:" + spanToString());
+            SieveCoreferenceSystem.logger.finest("[Bergsma List] New gender assigned:\tNeutral:\t" +  headString + "\tspan:" + spanToString());
           }
         }
       }

--- a/src/edu/stanford/nlp/dcoref/MentionExtractor.java
+++ b/src/edu/stanford/nlp/dcoref/MentionExtractor.java
@@ -429,7 +429,7 @@ public class MentionExtractor {
       annoSb.append(", parse");
     }
     String annoStr = annoSb.toString();
-    SieveCoreferenceSystem.logger.info("MentionExtractor ignores specified annotators, using annotators=" + annoStr);
+    SieveCoreferenceSystem.logger.finest("MentionExtractor ignores specified annotators, using annotators=" + annoStr);
     pipelineProps.setProperty("annotators", annoStr);
     return new StanfordCoreNLP(pipelineProps, false);
   }

--- a/src/edu/stanford/nlp/dcoref/RuleBasedCorefMentionFinder.java
+++ b/src/edu/stanford/nlp/dcoref/RuleBasedCorefMentionFinder.java
@@ -39,7 +39,7 @@ public class RuleBasedCorefMentionFinder implements CorefMentionFinder  {
   }
 
   public RuleBasedCorefMentionFinder(boolean allowReparsing) {
-    SieveCoreferenceSystem.logger.fine("Using SEMANTIC HEAD FINDER!!!!!!!!!!!!!!!!!!!");
+    SieveCoreferenceSystem.logger.finest("Using SEMANTIC HEAD FINDER!!!!!!!!!!!!!!!!!!!");
     this.headFinder = new SemanticHeadFinder();
     this.allowReparsing = allowReparsing;
   }

--- a/src/edu/stanford/nlp/dcoref/SieveCoreferenceSystem.java
+++ b/src/edu/stanford/nlp/dcoref/SieveCoreferenceSystem.java
@@ -336,8 +336,8 @@ public class SieveCoreferenceSystem  {
       throw new RuntimeException("Cannot initialize logger!", e);
     }
 
-    logger.fine(timeStamp);
-    logger.fine(props.toString());
+    logger.finest(timeStamp);
+    logger.finest(props.toString());
     Constants.printConstants(logger);
 
     // initialize coref system
@@ -389,9 +389,9 @@ public class SieveCoreferenceSystem  {
     } catch (Exception ex) {
       logger.log(Level.SEVERE, "ERROR in running coreference", ex);
     }
-    logger.info("done");
+    logger.finest("done");
     String endTimeStamp = Calendar.getInstance().getTime().toString().replaceAll("\\s", "-");
-    logger.fine(endTimeStamp);
+    logger.finest(endTimeStamp);
 
     return logFileName;
   }
@@ -423,12 +423,12 @@ public class SieveCoreferenceSystem  {
       conllMentionEvalErrFile = conllOutput +"-"+timeStamp+ ".eval.err.txt";
       conllMentionCorefEvalFile = conllOutput +"-"+timeStamp+ ".coref.eval.txt";
       conllMentionCorefEvalErrFile = conllOutput +"-"+timeStamp+ ".coref.eval.err.txt";
-      logger.info("CONLL MENTION GOLD FILE: " + conllOutputMentionGoldFile);
-      logger.info("CONLL MENTION PREDICTED FILE: " + conllOutputMentionPredictedFile);
-      logger.info("CONLL MENTION EVAL FILE: " + conllMentionEvalFile);
+      logger.finest("CONLL MENTION GOLD FILE: " + conllOutputMentionGoldFile);
+      logger.finest("CONLL MENTION PREDICTED FILE: " + conllOutputMentionPredictedFile);
+      logger.finest("CONLL MENTION EVAL FILE: " + conllMentionEvalFile);
       if (!Constants.SKIP_COREF) {
-        logger.info("CONLL MENTION PREDICTED WITH COREF FILE: " + conllOutputMentionCorefPredictedFile);
-        logger.info("CONLL MENTION WITH COREF EVAL FILE: " + conllMentionCorefEvalFile);
+        logger.finest("CONLL MENTION PREDICTED WITH COREF FILE: " + conllOutputMentionCorefPredictedFile);
+        logger.finest("CONLL MENTION WITH COREF EVAL FILE: " + conllMentionCorefEvalFile);
       }
       writerGold = new PrintWriter(new FileOutputStream(conllOutputMentionGoldFile));
       writerPredicted = new PrintWriter(new FileOutputStream(conllOutputMentionPredictedFile));
@@ -480,11 +480,11 @@ public class SieveCoreferenceSystem  {
         //Identifying possible coreferring mentions in the corpus along with any recall/precision errors with gold corpus
         corefSystem.printTopK(logger, document, corefSystem.semantics);
 
-        logger.fine("pairwise score for this doc: ");
+        logger.finest("pairwise score for this doc: ");
         corefSystem.scoreSingleDoc.get(corefSystem.sieves.length-1).printF1(logger);
-        logger.fine("accumulated score: ");
+        logger.finest("accumulated score: ");
         corefSystem.printF1(true);
-        logger.fine("\n");
+        logger.finest("\n");
       }
       if(Constants.PRINT_CONLL_OUTPUT || corefSystem.replicateCoNLL){
         printConllOutput(document, writerPredictedCoref, false, true);
@@ -502,13 +502,13 @@ public class SieveCoreferenceSystem  {
         //        runConllEval(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionPredictedFile, conllMentionEvalFile, conllMentionEvalErrFile);
 
         String summary = getConllEvalSummary(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionPredictedFile);
-        logger.info("\nCONLL EVAL SUMMARY (Before COREF)");
+        logger.finest("\nCONLL EVAL SUMMARY (Before COREF)");
         printScoreSummary(summary, logger, false);
 
         if (!Constants.SKIP_COREF) {
           //          runConllEval(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionCorefPredictedFile, conllMentionCorefEvalFile, conllMentionCorefEvalErrFile);
           summary = getConllEvalSummary(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionCorefPredictedFile);
-          logger.info("\nCONLL EVAL SUMMARY (After COREF)");
+          logger.finest("\nCONLL EVAL SUMMARY (After COREF)");
           printScoreSummary(summary, logger, true);
           printFinalConllScore(summary);
           if (corefSystem.optimizeConllScore) {
@@ -529,7 +529,7 @@ public class SieveCoreferenceSystem  {
     }
 
     if (corefSystem.optimizeSieves) {
-      logger.info("Final reported score for sieve optimization " + corefSystem.optimizeScoreType + " : " + finalScore);
+      logger.finest("Final reported score for sieve optimization " + corefSystem.optimizeScoreType + " : " + finalScore);
     }
     return finalScore;
   }
@@ -550,7 +550,7 @@ public class SieveCoreferenceSystem  {
     Map<String,String> pbEnv = pb.environment();
     pbEnv.putAll(curEnv);
 
-    logger.info("Running distributed coref:" + StringUtils.join(pb.command(), " "));
+    logger.finest("Running distributed coref:" + StringUtils.join(pb.command(), " "));
     StringWriter outSos = new StringWriter();
     StringWriter errSos = new StringWriter();
     PrintWriter out = new PrintWriter(new BufferedWriter(outSos));
@@ -560,22 +560,22 @@ public class SieveCoreferenceSystem  {
     err.close();
     String outStr = outSos.toString();
     String errStr = errSos.toString();
-    logger.info("Finished distributed coref: " + runDistCmd + ", props=" + propsFile);
-    logger.info("Output: " + outStr);
+    logger.finest("Finished distributed coref: " + runDistCmd + ", props=" + propsFile);
+    logger.finest("Output: " + outStr);
     if (errStr.length() > 0) {
-      logger.info("Error: " + errStr);
+      logger.finest("Error: " + errStr);
     }
   }
 
   static boolean waitForFiles(File workDir, FileFilter fileFilter, int howMany) throws InterruptedException {
-    logger.info("Waiting until we see " + howMany + " " + fileFilter + " files in directory " + workDir + "...");
+    logger.finest("Waiting until we see " + howMany + " " + fileFilter + " files in directory " + workDir + "...");
     int seconds = 0;
     while (true) {
       File[] checkFiles = workDir.listFiles(fileFilter);
 
       // we found the required number of .check files
       if (checkFiles != null && checkFiles.length >= howMany) {
-        logger.info("Found " + checkFiles.length  + " " + fileFilter + " files. Continuing execution.");
+        logger.finest("Found " + checkFiles.length  + " " + fileFilter + " files. Continuing execution.");
         break;
       }
 
@@ -584,7 +584,7 @@ public class SieveCoreferenceSystem  {
       seconds += Constants.MONITOR_DIST_CMD_FINISHED_WAIT_MILLIS / 1000;
       if (seconds % 600 == 0) {
         double minutes = seconds / 60;
-        logger.info("Still waiting... " + minutes + " minutes have passed.");
+        logger.finest("Still waiting... " + minutes + " minutes have passed.");
       }
     }
     return true;
@@ -629,8 +629,8 @@ public class SieveCoreferenceSystem  {
    */
   public void optimizeSieveOrdering(MentionExtractor mentionExtractor, Properties props, String timestamp) throws Exception
   {
-    logger.info("=============SIEVE OPTIMIZATION START ====================");
-    logger.info("Optimize sieves using score: " + optimizeScoreType);
+    logger.finest("=============SIEVE OPTIMIZATION START ====================");
+    logger.finest("Optimize sieves using score: " + optimizeScoreType);
     FileFilter scoreFilesFilter = new FileFilter() {
       @Override
       public boolean accept(File file) {
@@ -659,7 +659,7 @@ public class SieveCoreferenceSystem  {
         sieves[i] = origSieves[optimizedOrdering.get(i)];
         sieveClassNames[i] = origSieveNames[optimizedOrdering.get(i)];
       }
-      logger.info("*** Optimizing Sieve ordering for pass " + curSievesNumber + " ***");
+      logger.finest("*** Optimizing Sieve ordering for pass " + curSievesNumber + " ***");
       // Get list of sieves that we can pick from for the next sieve
       Set<Integer> selectableSieveIndices = new TreeSet<>(remainingSieveIndices);
       // Based on ordering constraints remove sieves from options
@@ -667,7 +667,7 @@ public class SieveCoreferenceSystem  {
         for (Pair<Integer,Integer> ko:sievesKeepOrder) {
           if (ko.second() < 0) {
             if (remainingSieveIndices.contains(ko.first())) {
-              logger.info("Restrict selection to " + origSieveNames[ko.first()] + " because of constraint " +
+              logger.finest("Restrict selection to " + origSieveNames[ko.first()] + " because of constraint " +
                       toSieveOrderConstraintString(ko, origSieveNames));
               selectableSieveIndices = Generics.newHashSet(1);
               selectableSieveIndices.add(ko.first());
@@ -675,13 +675,13 @@ public class SieveCoreferenceSystem  {
             }
           } else if (ko.first() < 0 && remainingSieveIndices.size() > 1) {
             if (remainingSieveIndices.contains(ko.second())) {
-              logger.info("Remove selection " + origSieveNames[ko.second()] + " because of constraint " +
+              logger.finest("Remove selection " + origSieveNames[ko.second()] + " because of constraint " +
                     toSieveOrderConstraintString(ko, origSieveNames));
               selectableSieveIndices.remove(ko.second());
             }
           } else if (remainingSieveIndices.contains(ko.first())) {
             if (remainingSieveIndices.contains(ko.second())) {
-              logger.info("Remove selection " + origSieveNames[ko.second()] + " because of constraint " +
+              logger.finest("Remove selection " + origSieveNames[ko.second()] + " because of constraint " +
                     toSieveOrderConstraintString(ko, origSieveNames));
               selectableSieveIndices.remove(ko.second());
             }
@@ -748,14 +748,14 @@ public class SieveCoreferenceSystem  {
             // try this sieve and see how well it works
             sieves[curSievesNumber] = origSieves[potentialSieveIndex];
             sieveClassNames[curSievesNumber] = origSieveNames[potentialSieveIndex];
-            logger.info("Trying sieve " + curSievesNumber + "="+ sieveClassNames[curSievesNumber] + ": ");
-            logger.info(" Trying sieves: " + StringUtils.join(sieveClassNames,","));
+            logger.finest("Trying sieve " + curSievesNumber + "="+ sieveClassNames[curSievesNumber] + ": ");
+            logger.finest(" Trying sieves: " + StringUtils.join(sieveClassNames,","));
 
             double score = runAndScoreCoref(this, mentionExtractor, props, timestamp);
             // keeps scores so we can select best score and log them
             scores.add(new Pair<>(score, potentialSieveIndex));
-            logger.info(" Trying sieves: " + StringUtils.join(sieveClassNames,","));
-            logger.info(" Trying sieves score: " + score);
+            logger.finest(" Trying sieves: " + StringUtils.join(sieveClassNames,","));
+            logger.finest(" Trying sieves score: " + score);
           }
         }
         // Select bestScore
@@ -769,27 +769,27 @@ public class SieveCoreferenceSystem  {
         // log ordered scores
         Collections.sort(scores);
         Collections.reverse(scores);
-        logger.info("Ordered sieves");
+        logger.finest("Ordered sieves");
         for (Pair<Double,Integer> p:scores) {
-          logger.info("Sieve optimization pass " + curSievesNumber
+          logger.finest("Sieve optimization pass " + curSievesNumber
                   + " scores: Sieve=" + origSieveNames[p.second()] + ", score=" + p.first());
         }
       } else {
         // Only one sieve
-        logger.info("Only one choice for next sieve");
+        logger.finest("Only one choice for next sieve");
         selected = selectableSieveIndices.iterator().next();
       }
       // log sieve we are adding
       sieves[curSievesNumber] = origSieves[selected];
       sieveClassNames[curSievesNumber] = origSieveNames[selected];
-      logger.info("Adding sieve " + curSievesNumber + "="+ sieveClassNames[curSievesNumber] + " to existing sieves: ");
-      logger.info(" Current Sieves: " + StringUtils.join(sieveClassNames,","));
+      logger.finest("Adding sieve " + curSievesNumber + "="+ sieveClassNames[curSievesNumber] + " to existing sieves: ");
+      logger.finest(" Current Sieves: " + StringUtils.join(sieveClassNames,","));
       // select optimal sieve and add it to our optimized ordering
       optimizedOrdering.add(selected);
       remainingSieveIndices.remove(selected);
     }
-    logger.info("Final Sieve Ordering: " + StringUtils.join(sieveClassNames, ","));
-    logger.info("=============SIEVE OPTIMIZATION DONE ====================");
+    logger.finest("Final Sieve Ordering: " + StringUtils.join(sieveClassNames, ","));
+    logger.finest("=============SIEVE OPTIMIZATION DONE ====================");
   }
 
   /**
@@ -893,7 +893,7 @@ public class SieveCoreferenceSystem  {
       DeterministicCorefSieve sieve) throws Exception {
 
     //Redwood.forceTrack("Coreference: sieve " + sieve.getClass().getSimpleName());
-    logger.finer("Coreference: sieve " + sieve.getClass().getSimpleName());
+    logger.finest("Coreference: sieve " + sieve.getClass().getSimpleName());
     List<List<Mention>> orderedMentionsBySentence = document.getOrderedMentions();
     Map<Integer, CorefCluster> corefClusters = document.corefClusters;
     Set<Mention> roleSet = document.roleSet;
@@ -1112,7 +1112,7 @@ public class SieveCoreferenceSystem  {
     Map<Mention, IntTuple> positions = document.allPositions;
     Map<Integer, Mention> golds = document.allGoldMentions;
 
-    logger.fine("=======ERROR ANALYSIS=========================================================");
+    logger.finest("=======ERROR ANALYSIS=========================================================");
 
     // Temporary sieve for getting ordered antecedents
     DeterministicCorefSieve tmpSieve = new ExactStringMatch();
@@ -1120,15 +1120,15 @@ public class SieveCoreferenceSystem  {
       List<Mention> orderedMentions = orderedMentionsBySentence.get(i);
       for (int j = 0 ; j < orderedMentions.size(); j++) {
         Mention m = orderedMentions.get(j);
-        logger.fine("=========Line: "+i+"\tmention: "+j+"=======================================================");
-        logger.fine(m.spanToString()+"\tmentionID: "+m.mentionID+"\tcorefClusterID: "+m.corefClusterID+"\tgoldCorefClusterID: "+m.goldCorefClusterID);
+        logger.finest("=========Line: "+i+"\tmention: "+j+"=======================================================");
+        logger.finest(m.spanToString()+"\tmentionID: "+m.mentionID+"\tcorefClusterID: "+m.corefClusterID+"\tgoldCorefClusterID: "+m.goldCorefClusterID);
         CorefCluster corefCluster = corefClusters.get(m.corefClusterID);
         if (corefCluster != null) {
           corefCluster.printCorefCluster(logger);
         } else {
-          logger.finer("CANNOT find coref cluster for cluster " + m.corefClusterID);
+          logger.finest("CANNOT find coref cluster for cluster " + m.corefClusterID);
         }
-        logger.fine("-------------------------------------------------------");
+        logger.finest("-------------------------------------------------------");
 
         boolean oneRecallErrorPrinted = false;
         boolean onePrecisionErrorPrinted = false;
@@ -1171,7 +1171,7 @@ public class SieveCoreferenceSystem  {
 
             String chosenness = chosen ? "Chosen" : "Not Chosen";
             String correctness = correct ? "Correct" : "Incorrect";
-            logger.fine("\t" + correctness +"\t\t" + chosenness + "\t"+antecedent.spanToString());
+            logger.finest("\t" + correctness +"\t\t" + chosenness + "\t"+antecedent.spanToString());
             CorefCluster mC = corefClusters.get(m.corefClusterID);
             CorefCluster aC = corefClusters.get(antecedent.corefClusterID);
 
@@ -1203,10 +1203,10 @@ public class SieveCoreferenceSystem  {
             if(chosen) alreadyChoose = true;
           }
         }
-        logger.fine("\n");
+        logger.finest("\n");
       }
     }
-    logger.fine("===============================================================================");
+    logger.finest("===============================================================================");
   }
 
   public void printF1(boolean printF1First) {
@@ -1216,28 +1216,28 @@ public class SieveCoreferenceSystem  {
   }
 
   private void printSieveScore(Document document, DeterministicCorefSieve sieve) {
-    logger.fine("===========================================");
-    logger.fine("pass"+currentSieve+": "+ sieve.flagsToString());
+    logger.finest("===========================================");
+    logger.finest("pass"+currentSieve+": "+ sieve.flagsToString());
     scoreMUC.get(currentSieve).printF1(logger);
     scoreBcubed.get(currentSieve).printF1(logger);
     scorePairwise.get(currentSieve).printF1(logger);
-    logger.fine("# of Clusters: "+document.corefClusters.size() + ",\t# of additional links: "+additionalLinksCount
+    logger.finest("# of Clusters: "+document.corefClusters.size() + ",\t# of additional links: "+additionalLinksCount
         +",\t# of additional correct links: "+additionalCorrectLinksCount
         +",\tprecision of new links: "+1.0*additionalCorrectLinksCount/additionalLinksCount);
-    logger.fine("# of total additional links: "+linksCountInPass.get(currentSieve).second()
+    logger.finest("# of total additional links: "+linksCountInPass.get(currentSieve).second()
         +",\t# of total additional correct links: "+linksCountInPass.get(currentSieve).first()
         +",\taccumulated precision of this pass: "+1.0*linksCountInPass.get(currentSieve).first()/linksCountInPass.get(currentSieve).second());
-    logger.fine("--------------------------------------");
+    logger.finest("--------------------------------------");
   }
   /** Print coref link info */
   private static void printLink(Logger logger, String header, IntTuple src, IntTuple dst, List<List<Mention>> orderedMentionsBySentence) {
     Mention srcMention = orderedMentionsBySentence.get(src.get(0)).get(src.get(1));
     Mention dstMention = orderedMentionsBySentence.get(dst.get(0)).get(dst.get(1));
     if(src.get(0)==dst.get(0)) {
-      logger.fine(header + ": ["+srcMention.spanToString()+"](id="+srcMention.mentionID
+      logger.finest(header + ": ["+srcMention.spanToString()+"](id="+srcMention.mentionID
           +") in sent #"+src.get(0)+" => ["+dstMention.spanToString()+"](id="+dstMention.mentionID+") in sent #"+dst.get(0) + " Same Sentence");
     } else {
-      logger.fine(header + ": ["+srcMention.spanToString()+"](id="+srcMention.mentionID
+      logger.finest(header + ": ["+srcMention.spanToString()+"](id="+srcMention.mentionID
           +") in sent #"+src.get(0)+" => ["+dstMention.spanToString()+"](id="+dstMention.mentionID+") in sent #"+dst.get(0));
     }
   }
@@ -1248,7 +1248,7 @@ public class SieveCoreferenceSystem  {
       sb.append(arg);
       sb.append('\t');
     }
-    logger.fine(sb.toString());
+    logger.finest(sb.toString());
   }
 
   /** print a coref link information including context and parse tree */
@@ -1280,7 +1280,7 @@ public class SieveCoreferenceSystem  {
         "utter: "+srcMention.headWord.get(CoreAnnotations.UtteranceAnnotation.class),
         "speakerID: "+srcMention.headWord.get(CoreAnnotations.SpeakerAnnotation.class),
         "twinless:" + srcMention.twinless);
-    logger.fine("Context:");
+    logger.finest("Context:");
 
     String p = "";
     for(int i = 0; i < srcSentence.size(); i++) {
@@ -1292,7 +1292,7 @@ public class SieveCoreferenceSystem  {
       }
       p += srcSentence.get(i).word() + " ";
     }
-    logger.fine(p);
+    logger.finest(p);
 
     StringBuilder golds = new StringBuilder();
     golds.append("Gold mentions in the sentence:\n");
@@ -1314,7 +1314,7 @@ public class SieveCoreferenceSystem  {
       golds.append(l.get(i).get(CoreAnnotations.TextAnnotation.class));
       golds.append(" ");
     }
-    logger.fine(golds.toString());
+    logger.finest(golds.toString());
 
     printList(logger, "\nAntecedent:" + dstMention.spanToString(),
         "Gender:" + dstMention.gender.toString(),
@@ -1327,7 +1327,7 @@ public class SieveCoreferenceSystem  {
         "utter: "+dstMention.headWord.get(CoreAnnotations.UtteranceAnnotation.class),
         "speakerID: "+dstMention.headWord.get(CoreAnnotations.SpeakerAnnotation.class),
         "twinless:" + dstMention.twinless);
-    logger.fine("Context:");
+    logger.finest("Context:");
 
     p = "";
     for(int i = 0; i < dstSentence.size(); i++) {
@@ -1339,7 +1339,7 @@ public class SieveCoreferenceSystem  {
       }
       p += dstSentence.get(i).word() + " ";
     }
-    logger.fine(p);
+    logger.finest(p);
 
     golds = new StringBuilder();
     golds.append("Gold mentions in the sentence:\n");
@@ -1361,20 +1361,20 @@ public class SieveCoreferenceSystem  {
       golds.append(l.get(i).get(CoreAnnotations.TextAnnotation.class));
       golds.append(" ");
     }
-    logger.fine(golds.toString());
+    logger.finest(golds.toString());
 
-    logger.finer("\nMention:: --------------------------------------------------------");
+    logger.finest("\nMention:: --------------------------------------------------------");
     try {
-      logger.finer(srcMention.dependency.toString());
+      logger.finest(srcMention.dependency.toString());
     } catch (Exception e){} //throw new RuntimeException(e);}
-    logger.finer("Parse:");
-    logger.finer(formatPennTree(srcMention.contextParseTree));
-    logger.finer("\nAntecedent:: -----------------------------------------------------");
+    logger.finest("Parse:");
+    logger.finest(formatPennTree(srcMention.contextParseTree));
+    logger.finest("\nAntecedent:: -----------------------------------------------------");
     try {
-      logger.finer(dstMention.dependency.toString());
+      logger.finest(dstMention.dependency.toString());
     } catch (Exception e){} //throw new RuntimeException(e);}
-    logger.finer("Parse:");
-    logger.finer(formatPennTree(dstMention.contextParseTree));
+    logger.finest("Parse:");
+    logger.finest(formatPennTree(dstMention.contextParseTree));
   }
   /** For printing tree in a better format */
   private static String formatPennTree(Tree parseTree)	{
@@ -1417,18 +1417,18 @@ public class SieveCoreferenceSystem  {
     logger.finest("\nsentence distance: "+(p1.get(0)-p2.get(0))+"\tmention distance: "+menDist + correct);
 
     if(!goldLinks.contains(new Pair<>(p1, p2))){
-      logger.finer("-------Incorrect merge in pass"+sieveIndex+"::--------------------");
+      logger.finest("-------Incorrect merge in pass"+sieveIndex+"::--------------------");
       c1.printCorefCluster(logger);
-      logger.finer("--------------------------------------------");
+      logger.finest("--------------------------------------------");
       c2.printCorefCluster(logger);
-      logger.finer("--------------------------------------------");
+      logger.finest("--------------------------------------------");
     }
-    logger.finer("antecedent: "+m2.spanToString()+"("+m2.mentionID+")\tmention: "+m1.spanToString()+"("+m1.mentionID+")\tsentDistance: "+Math.abs(m1.sentNum-m2.sentNum)+"\t"+correct+" Pass"+sieveIndex+":");
+    logger.finest("antecedent: "+m2.spanToString()+"("+m2.mentionID+")\tmention: "+m1.spanToString()+"("+m1.mentionID+")\tsentDistance: "+Math.abs(m1.sentNum-m2.sentNum)+"\t"+correct+" Pass"+sieveIndex+":");
   }
 
   private static void printDiscourseStructure(Document document) {
-    logger.finer("DISCOURSE STRUCTURE==============================");
-    logger.finer("doc type: "+document.docType);
+    logger.finest("DISCOURSE STRUCTURE==============================");
+    logger.finest("doc type: "+document.docType);
     int previousUtterIndex = -1;
     String previousSpeaker = "";
     StringBuilder sb = new StringBuilder();
@@ -1440,12 +1440,12 @@ public class SieveCoreferenceSystem  {
         if(previousUtterIndex!=utterIndex) {
           try {
             int previousSpeakerID = Integer.parseInt(previousSpeaker);
-            logger.finer("\n<utter>: "+previousUtterIndex + " <speaker>: "+document.allPredictedMentions.get(previousSpeakerID).spanToString());
+            logger.finest("\n<utter>: "+previousUtterIndex + " <speaker>: "+document.allPredictedMentions.get(previousSpeakerID).spanToString());
           } catch (Exception e) {
             logger.finer("\n<utter>: "+previousUtterIndex + " <speaker>: "+previousSpeaker);
           }
 
-          logger.finer(sb.toString());
+          logger.finest(sb.toString());
           sb.setLength(0);
           previousUtterIndex = utterIndex;
           previousSpeaker = speaker;
@@ -1456,12 +1456,12 @@ public class SieveCoreferenceSystem  {
     }
     try {
       int previousSpeakerID = Integer.parseInt(previousSpeaker);
-      logger.finer("\n<utter>: "+previousUtterIndex + " <speaker>: "+document.allPredictedMentions.get(previousSpeakerID).spanToString());
+      logger.finest("\n<utter>: "+previousUtterIndex + " <speaker>: "+document.allPredictedMentions.get(previousSpeakerID).spanToString());
     } catch (Exception e) {
       logger.finer("\n<utter>: "+previousUtterIndex + " <speaker>: "+previousSpeaker);
     }
-    logger.finer(sb.toString());
-    logger.finer("END OF DISCOURSE STRUCTURE==============================");
+    logger.finest(sb.toString());
+    logger.finest("END OF DISCOURSE STRUCTURE==============================");
   }
 
   private static void printScoreSummary(String summary, Logger logger, boolean afterPostProcessing) {
@@ -1469,7 +1469,7 @@ public class SieveCoreferenceSystem  {
     if(!afterPostProcessing) {
       for(String line : lines) {
         if(line.startsWith("Identification of Mentions")) {
-          logger.info(line);
+          logger.finest(line);
           return;
         }
       }
@@ -1481,7 +1481,7 @@ public class SieveCoreferenceSystem  {
           sb.append(line).append("\n");
         }
       }
-      logger.info(sb.toString());
+      logger.finest(sb.toString());
     }
   }
   /** Print average F1 of MUC, B^3, CEAF_E */
@@ -1494,7 +1494,7 @@ public class SieveCoreferenceSystem  {
       F1s[i++] = Double.parseDouble(f1Matcher.group(1));
     }
     double finalScore = (F1s[0]+F1s[1]+F1s[3])/3;
-    logger.info("Final conll score ((muc+bcub+ceafe)/3) = " + (new DecimalFormat("#.##")).format(finalScore));
+    logger.finest("Final conll score ((muc+bcub+ceafe)/3) = " + (new DecimalFormat("#.##")).format(finalScore));
   }
 
   private static double getFinalConllScore(String summary, String metricType, String scoreType) {
@@ -1514,7 +1514,7 @@ public class SieveCoreferenceSystem  {
     metricType = metricType.toLowerCase();
     if ("combined".equals(metricType)) {
       double finalScore = (scores[0]+scores[1]+scores[3])/3;
-      logger.info("Final conll score ((muc+bcub+ceafe)/3) " + scoreType + " = " + finalScore);
+      logger.finest("Final conll score ((muc+bcub+ceafe)/3) " + scoreType + " = " + finalScore);
       return finalScore;
     } else {
       if ("bcubed".equals(metricType)) {
@@ -1523,7 +1523,7 @@ public class SieveCoreferenceSystem  {
       for (i = 0; i < names.length; i++) {
         if (names[i] != null && names[i].equals(metricType)) {
           double finalScore = scores[i];
-          logger.info("Final conll score (" + metricType + ") " + scoreType + " = " + finalScore);
+          logger.finest("Final conll score (" + metricType + ") " + scoreType + " = " + finalScore);
           return finalScore;
         }
       }
@@ -1557,7 +1557,7 @@ public class SieveCoreferenceSystem  {
       default:
         throw new IllegalArgumentException("Invalid sub score type:" + subScoreType);
     }
-    logger.info("Final score (" + scoreDesc + ") " + subScoreType + " = " + (new DecimalFormat("#.##")).format(finalScore));
+    logger.finest("Final score (" + scoreDesc + ") " + subScoreType + " = " + (new DecimalFormat("#.##")).format(finalScore));
     return finalScore;
   }
 
@@ -1708,13 +1708,13 @@ public class SieveCoreferenceSystem  {
 
       doc.append("\n");
     }
-    logger.fine(document.annotation.get(CoreAnnotations.DocIDAnnotation.class));
+    logger.finest(document.annotation.get(CoreAnnotations.DocIDAnnotation.class));
     if (gold) {
-      logger.fine("New DOC: (GOLD MENTIONS) ==================================================");
+      logger.finest("New DOC: (GOLD MENTIONS) ==================================================");
     } else {
-      logger.fine("New DOC: (Predicted Mentions) ==================================================");
+      logger.finest("New DOC: (Predicted Mentions) ==================================================");
     }
-    logger.fine(doc.toString());
+    logger.finest(doc.toString());
   }
   public static List<Pair<IntTuple, IntTuple>> getLinks(
       Map<Integer, CorefChain> result) {

--- a/src/edu/stanford/nlp/ie/machinereading/BasicEntityExtractor.java
+++ b/src/edu/stanford/nlp/ie/machinereading/BasicEntityExtractor.java
@@ -174,7 +174,7 @@ public class BasicEntityExtractor implements Extractor  {
       // this is an entity end boundary followed by O
       if (type == null && lastType != null) {
         makeEntityMention(sentence, startIndex, i, lastType, extractedEntities, sentCount);
-        logger.info("Found entity: " + extractedEntities.get(extractedEntities.size() - 1));
+        logger.finest("Found entity: " + extractedEntities.get(extractedEntities.size() - 1));
         startIndex = -1;
       }
 
@@ -189,7 +189,7 @@ public class BasicEntityExtractor implements Extractor  {
           (lastType.startsWith("I-") && type.startsWith("I-") && ! lastType.equals(type)) ||
           (notBIO(lastType) && notBIO(type) && ! lastType.equals(type)))){
         makeEntityMention(sentence, startIndex, i, lastType, extractedEntities, sentCount);
-        logger.info("Found entity: " + extractedEntities.get(extractedEntities.size() - 1));
+        logger.finest("Found entity: " + extractedEntities.get(extractedEntities.size() - 1));
         startIndex = i;
       }
 
@@ -254,7 +254,7 @@ public class BasicEntityExtractor implements Extractor  {
             new Span(start, end),
             new Span(start, end),
             entityType, null, null);
-        logger.info("Created " + entityType + " entity mention: " + m);
+        logger.finest("Created " + entityType + " entity mention: " + m);
         start = end - 1;
         mentions.add(m);
       }
@@ -278,7 +278,7 @@ public class BasicEntityExtractor implements Extractor  {
     assert words != null;
     if(mentions == null)
     {  
-      this.logger.info("mentions are null");
+      this.logger.finest("mentions are null");
       mentions = new ArrayList<>();
     }
 
@@ -307,7 +307,7 @@ public class BasicEntityExtractor implements Extractor  {
             new Span(start, end),
             entityType, null, null);
         //TODO: changed entityType in the above sentence to nerTag - Sonal
-        logger.info("Created " + entityType + " entity mention: " + m);
+        logger.finest("Created " + entityType + " entity mention: " + m);
         start = end - 1;
         mentions.add(m);
       }

--- a/src/edu/stanford/nlp/ie/machinereading/BasicRelationExtractor.java
+++ b/src/edu/stanford/nlp/ie/machinereading/BasicRelationExtractor.java
@@ -127,7 +127,7 @@ public class BasicRelationExtractor implements Extractor {
   }
 
   protected static void reportWeights(LinearClassifier<String, String> classifier, String classLabel) {
-    if (classLabel != null) logger.fine("CLASSIFIER WEIGHTS FOR LABEL " + classLabel);
+    if (classLabel != null) logger.finest("CLASSIFIER WEIGHTS FOR LABEL " + classLabel);
     Map<String, Counter<String>> labelsToFeatureWeights = classifier.weightsAsMapOfCounters();
     List<String> labels = new ArrayList<>(labelsToFeatureWeights.keySet());
     Collections.sort(labels);
@@ -139,7 +139,7 @@ public class BasicRelationExtractor implements Extractor {
       for (Pair<String, Double> feat: sorted) {
         bos.append(' ').append(feat.first()).append(':').append(feat.second()+"\n");
       }
-      logger.fine(bos.toString());
+      logger.finest(bos.toString());
     }
   }
 
@@ -199,11 +199,11 @@ public class BasicRelationExtractor implements Extractor {
       if (logger.isLoggable(Level.INFO)) {
         justificationOf(testDatum, pw, label);
       }
-      logger.info("Current sentence: " + AnnotationUtils.tokensAndNELabelsToString(rel.getArg(0).getSentence()) + "\n"
+      logger.finest("Current sentence: " + AnnotationUtils.tokensAndNELabelsToString(rel.getArg(0).getSentence()) + "\n"
               + "Classifying relation: " + rel + "\n"
               + "JUSTIFICATION for label GOLD:" + rel.getType() + " SYS:" + label + " (prob:" + prob + "):\n"
               + sw.toString());
-      logger.info("Justification done.");
+      logger.finest("Justification done.");
       RelationMention relation = relationMentionFactory.constructRelationMention(
               rel.getObjectId(),
               sentence,
@@ -215,13 +215,13 @@ public class BasicRelationExtractor implements Extractor {
       extractions.add(relation);
 
       if(! relation.getType().equals(rel.getType())){
-        logger.info("Classification: found different type " + relation.getType() + " for relation: " + rel);
-        logger.info("The predicted relation is: " + relation);
-        logger.info("Current sentence: " + AnnotationUtils.tokensAndNELabelsToString(rel.getArg(0).getSentence()));
+        logger.finest("Classification: found different type " + relation.getType() + " for relation: " + rel);
+        logger.finest("The predicted relation is: " + relation);
+        logger.finest("Current sentence: " + AnnotationUtils.tokensAndNELabelsToString(rel.getArg(0).getSentence()));
       } else{
-        logger.info("Classification: found similar type " + relation.getType() + " for relation: " + rel);
-        logger.info("The predicted relation is: " + relation);
-        logger.info("Current sentence: " + AnnotationUtils.tokensAndNELabelsToString(rel.getArg(0).getSentence()));
+        logger.finest("Classification: found similar type " + relation.getType() + " for relation: " + rel);
+        logger.finest("The predicted relation is: " + relation);
+        logger.finest("Current sentence: " + AnnotationUtils.tokensAndNELabelsToString(rel.getArg(0).getSentence()));
       }
     }
     return extractions;
@@ -240,14 +240,14 @@ public class BasicRelationExtractor implements Extractor {
       if (logger.isLoggable(Level.FINE)) {
         justificationOf(testDatum, pw, label);
       }
-      logger.fine("JUSTIFICATION for label GOLD:" + testDatum.label() + " SYS:" + label + " (prob:" + prob + "):\n"
+      logger.finest("JUSTIFICATION for label GOLD:" + testDatum.label() + " SYS:" + label + " (prob:" + prob + "):\n"
               + sw.toString() + "\nJustification done.");
       predictedLabels.add(label);
 
       if(! testDatum.label().equals(label)){
-        logger.info("Classification: found different type " + label + " for relation: " + testDatum);
+        logger.finest("Classification: found different type " + label + " for relation: " + testDatum);
       } else{
-        logger.info("Classification: found similar type " + label + " for relation: " + testDatum);
+        logger.finest("Classification: found similar type " + label + " for relation: " + testDatum);
       }
     }
 
@@ -269,7 +269,7 @@ public class BasicRelationExtractor implements Extractor {
     // caution: this removes the old list of relation mentions!
     for (RelationMention r: relations) {
       if (! r.getType().equals(RelationMention.UNRELATED)) {
-        logger.fine("Found positive relation in annotateSentence: " + r);
+        logger.finest("Found positive relation in annotateSentence: " + r);
       }
     }
     sentence.set(MachineReadingAnnotations.RelationMentionsAnnotation.class, relations);

--- a/src/edu/stanford/nlp/ie/machinereading/BasicRelationFeatureFactory.java
+++ b/src/edu/stanford/nlp/ie/machinereading/BasicRelationFeatureFactory.java
@@ -211,7 +211,7 @@ public class BasicRelationFeatureFactory extends RelationFeatureFactory implemen
           pathStringBuilder.append(((node == join) ? "" : " -> ") + node.label().value());
         }
         String pathString = pathStringBuilder.toString();
-        if(logger != null && ! rel.getType().equals(RelationMention.UNRELATED)) logger.info("full_tree_path: " + pathString);
+        if(logger != null && ! rel.getType().equals(RelationMention.UNRELATED)) logger.finest("full_tree_path: " + pathString);
         features.setCount("treepath:"+pathString, 1.0);
       } else {
         log.info("WARNING: found weird argument offsets. Most likely because arguments appear in different sentences than the relation:");
@@ -646,7 +646,7 @@ public class BasicRelationFeatureFactory extends RelationFeatureFactory implemen
     }
     if (usingFeature(types, checklist, "dependency_path_lowlevel")) {
       String depLowLevel = dependencyPath(edgePath, node0);
-      if(logger != null && ! rel.getType().equals(RelationMention.UNRELATED)) logger.info("dependency_path_lowlevel: " + depLowLevel);
+      if(logger != null && ! rel.getType().equals(RelationMention.UNRELATED)) logger.finest("dependency_path_lowlevel: " + depLowLevel);
       features.setCount("dependency_path_lowlevel:" + depLowLevel, 1.0);
     }
 

--- a/src/edu/stanford/nlp/ie/machinereading/ExtractorMerger.java
+++ b/src/edu/stanford/nlp/ie/machinereading/ExtractorMerger.java
@@ -36,7 +36,7 @@ public class ExtractorMerger implements Extractor {
   @Override
   public void annotate(Annotation dataset) {
     // TODO for now, we only merge RelationMentions
-    logger.info("Extractor 0 annotating dataset.");
+    logger.finest("Extractor 0 annotating dataset.");
     extractors[0].annotate(dataset);
 
     // store all the RelationMentions per sentence
@@ -49,7 +49,7 @@ public class ExtractorMerger implements Extractor {
 
     // skip first extractor since we did it at the top
     for (int extractorIndex = 1; extractorIndex < extractors.length; extractorIndex++) {
-      logger.info("Extractor " + extractorIndex + " annotating dataset.");
+      logger.finest("Extractor " + extractorIndex + " annotating dataset.");
       Extractor extractor = extractors[extractorIndex];
       extractor.annotate(dataset);
 
@@ -75,7 +75,7 @@ public class ExtractorMerger implements Extractor {
     BasicRelationExtractor[] relationExtractorComponents = new BasicRelationExtractor[extractorModelNames.length];
     for (int i = 0; i < extractorModelNames.length; i++) {
       String modelName = extractorModelNames[i];
-      logger.info("Loading model " + i + " for model merging from " + modelName);
+      logger.finest("Loading model " + i + " for model merging from " + modelName);
       try {
         relationExtractorComponents[i] = BasicRelationExtractor.load(modelName);
       } catch (IOException | ClassNotFoundException e) {

--- a/src/edu/stanford/nlp/ie/machinereading/MachineReading.java
+++ b/src/edu/stanford/nlp/ie/machinereading/MachineReading.java
@@ -300,7 +300,7 @@ public class MachineReading  {
       train(datasets[partition].first(), (MachineReadingProperties.crossValidate ? partition : -1));
       // annotate using all models
       if(! MachineReadingProperties.trainOnly){
-        MachineReadingProperties.logger.info("annotating partition " + partition );
+        MachineReadingProperties.logger.finest("annotating partition " + partition );
         annotate(datasets[partition].second(), (MachineReadingProperties.crossValidate ? partition: -1));
       }
     }
@@ -365,21 +365,21 @@ public class MachineReading  {
     // train entity extraction
     //
     if (MachineReadingProperties.extractEntities) {
-      MachineReadingProperties.logger.info("Training entity extraction model(s)");
-      if (partition != -1) MachineReadingProperties.logger.info("In partition #" + partition);
+      MachineReadingProperties.logger.finest("Training entity extraction model(s)");
+      if (partition != -1) MachineReadingProperties.logger.finest("In partition #" + partition);
       String modelName = MachineReadingProperties.serializedEntityExtractorPath;
       if (partition != -1) modelName += "." + partition;
       File modelFile = new File(modelName);
 
-      MachineReadingProperties.logger.fine("forceRetraining = " + this.forceRetraining+ ", modelFile.exists = " + modelFile.exists());
+      MachineReadingProperties.logger.finest("forceRetraining = " + this.forceRetraining+ ", modelFile.exists = " + modelFile.exists());
       if(! this.forceRetraining&& modelFile.exists()){
-        MachineReadingProperties.logger.info("Loading entity extraction model from " + modelName + " ...");
+        MachineReadingProperties.logger.finest("Loading entity extraction model from " + modelName + " ...");
         entityExtractor = BasicEntityExtractor.load(modelName, MachineReadingProperties.entityClassifier, false);
       } else {
-        MachineReadingProperties.logger.info("Training entity extraction model...");
+        MachineReadingProperties.logger.finest("Training entity extraction model...");
         entityExtractor = makeEntityExtractor(MachineReadingProperties.entityClassifier, MachineReadingProperties.entityGazetteerPath);
         entityExtractor.train(training);
-        MachineReadingProperties.logger.info("Serializing entity extraction model to " + modelName + " ...");
+        MachineReadingProperties.logger.finest("Serializing entity extraction model to " + modelName + " ...");
         entityExtractor.save(modelName);
       }
     }
@@ -388,9 +388,9 @@ public class MachineReading  {
     // train relation extraction
     //
     if (MachineReadingProperties.extractRelations) {
-      MachineReadingProperties.logger.info("Training relation extraction model(s)");
+      MachineReadingProperties.logger.finest("Training relation extraction model(s)");
       if (partition != -1)
-        MachineReadingProperties.logger.info("In partition #" + partition);
+        MachineReadingProperties.logger.finest("In partition #" + partition);
       String modelName = MachineReadingProperties.serializedRelationExtractorPath;
       if (partition != -1)
         modelName += "." + partition;
@@ -405,7 +405,7 @@ public class MachineReading  {
 
         relationExtractor = ExtractorMerger.buildRelationExtractorMerger(modelNames);
       } else if (!this.forceRetraining&& new File(modelName).exists()) {
-        MachineReadingProperties.logger.info("Loading relation extraction model from " + modelName + " ...");
+        MachineReadingProperties.logger.finest("Loading relation extraction model from " + modelName + " ...");
         //TODO change this to load any type of BasicRelationExtractor
         relationExtractor = BasicRelationExtractor.load(modelName);
       } else {
@@ -420,7 +420,7 @@ public class MachineReading  {
           entityExtractor.annotate(predicted);
           for (ResultsPrinter rp : entityResultsPrinterSet){
             String msg = rp.printResults(training, predicted);
-            MachineReadingProperties.logger.info("Training relation extraction using predicted entitities: entity scores using printer " + rp.getClass() + ":\n" + msg);
+            MachineReadingProperties.logger.finest("Training relation extraction using predicted entitities: entity scores using printer " + rp.getClass() + ":\n" + msg);
           }
 
           // change relation mentions to use predicted entity mentions rather than gold ones
@@ -456,9 +456,9 @@ public class MachineReading  {
                 makeRelationMentionFactory(MachineReadingProperties.relationMentionFactoryClass));
         ArgumentParser.fillOptions(relationExtractor, args);
         //Arguments.parse(args,relationExtractor);
-        MachineReadingProperties.logger.info("Training relation extraction model...");
+        MachineReadingProperties.logger.finest("Training relation extraction model...");
         relationExtractor.train(dataset);
-        MachineReadingProperties.logger.info("Serializing relation extraction model to " + modelName + " ...");
+        MachineReadingProperties.logger.finest("Serializing relation extraction model to " + modelName + " ...");
         relationExtractor.save(modelName);
 
         if (relationsToSkip.size() > 0) {
@@ -478,14 +478,14 @@ public class MachineReading  {
     // train event extraction -- currently just works with MSTBasedEventExtractor
     //
     if (MachineReadingProperties.extractEvents) {
-      MachineReadingProperties.logger.info("Training event extraction model(s)");
-      if (partition != -1) MachineReadingProperties.logger.info("In partition #" + partition);
+      MachineReadingProperties.logger.finest("Training event extraction model(s)");
+      if (partition != -1) MachineReadingProperties.logger.finest("In partition #" + partition);
       String modelName = MachineReadingProperties.serializedEventExtractorPath;
       if (partition != -1) modelName += "." + partition;
       File modelFile = new File(modelName);
 
       if(!this.forceRetraining&& modelFile.exists()) {
-        MachineReadingProperties.logger.info("Loading event extraction model from " + modelName + " ...");
+        MachineReadingProperties.logger.finest("Loading event extraction model from " + modelName + " ...");
         Method mstLoader = (Class.forName("MSTBasedEventExtractor")).getMethod("load", String.class);
         eventExtractor = (Extractor) mstLoader.invoke(null, modelName);
       } else {
@@ -497,7 +497,7 @@ public class MachineReading  {
           entityExtractor.annotate(predicted);
           for (ResultsPrinter rp : entityResultsPrinterSet){
             String msg = rp.printResults(training, predicted);
-            MachineReadingProperties.logger.info("Training event extraction using predicted entitities: entity scores using printer " + rp.getClass() + ":\n" + msg);
+            MachineReadingProperties.logger.finest("Training event extraction using predicted entitities: entity scores using printer " + rp.getClass() + ":\n" + msg);
           }
 
           // TODO: need an equivalent of changeGoldRelationArgsToPredicted here?
@@ -506,13 +506,13 @@ public class MachineReading  {
         Constructor<?> mstConstructor = (Class.forName("edu.stanford.nlp.ie.machinereading.MSTBasedEventExtractor")).getConstructor(boolean.class);
         eventExtractor = (Extractor) mstConstructor.newInstance(MachineReadingProperties.trainEventsUsingPredictedEntities);
 
-        MachineReadingProperties.logger.info("Training event extraction model...");
+        MachineReadingProperties.logger.finest("Training event extraction model...");
         if (MachineReadingProperties.trainRelationsUsingPredictedEntities) {
           eventExtractor.train(predicted);
         } else {
           eventExtractor.train(training);
         }
-        MachineReadingProperties.logger.info("Serializing event extraction model to " + modelName + " ...");
+        MachineReadingProperties.logger.finest("Serializing event extraction model to " + modelName + " ...");
         eventExtractor.save(modelName);
       }
     }
@@ -551,10 +551,10 @@ public class MachineReading  {
       for (RelationMention rm : relationMentions) {
         rm.setSentence(sent);
         if (rm.replaceGoldArgsWithPredicted(entityMentions)) {
-          MachineReadingProperties.logger.info("Successfully mapped all arguments in relation mention: " + rm);
+          MachineReadingProperties.logger.finest("Successfully mapped all arguments in relation mention: " + rm);
           newRels.add(rm);
         } else {
-          MachineReadingProperties.logger.info("Dropped relation mention due to failed argument mapping: " + rm);
+          MachineReadingProperties.logger.finest("Dropped relation mention due to failed argument mapping: " + rm);
         }
       }
       sent.set(MachineReadingAnnotations.RelationMentionsAnnotation.class, newRels);
@@ -580,7 +580,7 @@ public class MachineReading  {
 
       for (ResultsPrinter rp : entityResultsPrinterSet){
         String msg = rp.printResults(testing, predicted);
-        MachineReadingProperties.logger.info("Entity extraction results " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
+        MachineReadingProperties.logger.finest("Entity extraction results " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
       }
       predictions[ENTITY_LEVEL][partitionIndex] = predicted;
     }
@@ -600,13 +600,13 @@ public class MachineReading  {
         relationExtractionPostProcessor = makeExtractor(MachineReadingProperties.relationExtractionPostProcessorClass);
       }
       if (relationExtractionPostProcessor != null) {
-        MachineReadingProperties.logger.info("Using relation extraction post processor: " + MachineReadingProperties.relationExtractionPostProcessorClass);
+        MachineReadingProperties.logger.finest("Using relation extraction post processor: " + MachineReadingProperties.relationExtractionPostProcessorClass);
         relationExtractionPostProcessor.annotate(predicted);
       }
 
       for (ResultsPrinter rp : getRelationResultsPrinterSet()){
         String msg = rp.printResults(testing, predicted);
-        MachineReadingProperties.logger.info("Relation extraction results " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
+        MachineReadingProperties.logger.finest("Relation extraction results " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
       }
 
       //
@@ -616,16 +616,16 @@ public class MachineReading  {
         consistencyChecker = makeExtractor(MachineReadingProperties.consistencyCheck);
       }
       if (consistencyChecker != null) {
-        MachineReadingProperties.logger.info("Using consistency checker: " + MachineReadingProperties.consistencyCheck);
+        MachineReadingProperties.logger.finest("Using consistency checker: " + MachineReadingProperties.consistencyCheck);
         consistencyChecker.annotate(predicted);
 
         for (ResultsPrinter rp : entityResultsPrinterSet){
           String msg = rp.printResults(testing, predicted);
-          MachineReadingProperties.logger.info("Entity extraction results AFTER consistency checks " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
+          MachineReadingProperties.logger.finest("Entity extraction results AFTER consistency checks " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
         }
         for (ResultsPrinter rp : getRelationResultsPrinterSet()){
           String msg = rp.printResults(testing, predicted);
-          MachineReadingProperties.logger.info("Relation extraction results AFTER consistency checks " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
+          MachineReadingProperties.logger.finest("Relation extraction results AFTER consistency checks " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
         }
       }
 
@@ -693,7 +693,7 @@ public class MachineReading  {
       for (int partition = 0; partition <MachineReadingProperties.kfold; partition++) {
         int begin = AnnotationUtils.sentenceCount(training) * partition / MachineReadingProperties.kfold;
         int end = AnnotationUtils.sentenceCount(training) * (partition + 1) / MachineReadingProperties.kfold;
-        MachineReadingProperties.logger.info("Creating partition #" + partition + " using offsets [" + begin + ", " + end + ") out of " + AnnotationUtils.sentenceCount(training));
+        MachineReadingProperties.logger.finest("Creating partition #" + partition + " using offsets [" + begin + ", " + end + ") out of " + AnnotationUtils.sentenceCount(training));
         Annotation partitionTrain = new Annotation("");
         Annotation partitionTest = new Annotation("");
         for(int i = 0; i < AnnotationUtils.sentenceCount(training); i ++){
@@ -768,7 +768,7 @@ public class MachineReading  {
   }
 
   private static Set<ResultsPrinter> makeResultsPrinters(String classes, String[] args) {
-    MachineReadingProperties.logger.info("Making result printers from " + classes);
+    MachineReadingProperties.logger.finest("Making result printers from " + classes);
     String[] printerClassNames = classes.trim().split(",\\s*");
     HashSet<ResultsPrinter> printers = new HashSet<>();
     for (String printerClassName : printerClassNames) {
@@ -897,22 +897,22 @@ public class MachineReading  {
     // if the serialized file exists, just read it. otherwise read the source
     // and and save the serialized file to disk
     if (MachineReadingProperties.serializeCorpora && serializedSentences.exists() && !forceParseSentences) {
-      MachineReadingProperties.logger.info("Loaded serialized sentences from " + serializedSentences.getAbsolutePath() + "...");
+      MachineReadingProperties.logger.finest("Loaded serialized sentences from " + serializedSentences.getAbsolutePath() + "...");
       corpusSentences = IOUtils.readObjectFromFile(serializedSentences);
-      MachineReadingProperties.logger.info("Done. Loaded " + corpusSentences.get(CoreAnnotations.SentencesAnnotation.class).size() + " sentences.");
+      MachineReadingProperties.logger.finest("Done. Loaded " + corpusSentences.get(CoreAnnotations.SentencesAnnotation.class).size() + " sentences.");
     } else {
       // read the corpus
-      MachineReadingProperties.logger.info("Parsing corpus sentences...");
+      MachineReadingProperties.logger.finest("Parsing corpus sentences...");
       if(MachineReadingProperties.serializeCorpora)
-        MachineReadingProperties.logger.info("These sentences will be serialized to " + serializedSentences.getAbsolutePath());
+        MachineReadingProperties.logger.finest("These sentences will be serialized to " + serializedSentences.getAbsolutePath());
       corpusSentences = reader.parse(sentencesPath);
-      MachineReadingProperties.logger.info("Done. Parsed " + AnnotationUtils.sentenceCount(corpusSentences) + " sentences.");
+      MachineReadingProperties.logger.finest("Done. Parsed " + AnnotationUtils.sentenceCount(corpusSentences) + " sentences.");
 
       // save corpusSentences
       if(MachineReadingProperties.serializeCorpora){
-        MachineReadingProperties.logger.info("Serializing parsed sentences to " + serializedSentences.getAbsolutePath() + "...");
+        MachineReadingProperties.logger.finest("Serializing parsed sentences to " + serializedSentences.getAbsolutePath() + "...");
         IOUtils.writeObjectToFile(corpusSentences,serializedSentences);
-        MachineReadingProperties.logger.info("Done. Serialized " + AnnotationUtils.sentenceCount(corpusSentences) + " sentences.");
+        MachineReadingProperties.logger.finest("Done. Serialized " + AnnotationUtils.sentenceCount(corpusSentences) + " sentences.");
       }
     }
     return corpusSentences;

--- a/src/edu/stanford/nlp/ie/machinereading/domains/ace/AceReader.java
+++ b/src/edu/stanford/nlp/ie/machinereading/domains/ace/AceReader.java
@@ -193,7 +193,7 @@ public class AceReader extends GenericDataSetReader  {
     for(String k: keys){
       b.append("\t").append(k).append(": ").append(c.getCount(k)).append("\n");
     }
-    logger.info(b.toString());
+    logger.finest(b.toString());
   }
 
    /**
@@ -222,7 +222,7 @@ public class AceReader extends GenericDataSetReader  {
    */
   private List<CoreMap> readDocument(String prefix, Annotation corpus) throws IOException, SAXException,
       ParserConfigurationException {
-    logger.info("Reading document: " + prefix);
+    logger.finest("Reading document: " + prefix);
     List<CoreMap> results = new ArrayList<>();
     AceDocument aceDocument;
     if(aceVersion.equals("ACE2004")){
@@ -273,7 +273,7 @@ public class AceReader extends GenericDataSetReader  {
       CoreMap sentence = new Annotation(textContent.toString());
       sentence.set(CoreAnnotations.DocIDAnnotation.class, docId);
       sentence.set(CoreAnnotations.TokensAnnotation.class, words);
-      logger.info("Reading sentence: \"" + textContent + "\"");
+      logger.finest("Reading sentence: \"" + textContent + "\"");
 
       List<AceEntityMention> entityMentions = aceDocument.getEntityMentions(sentenceIndex);
       List<AceRelationMention> relationMentions = aceDocument.getRelationMentions(sentenceIndex);
@@ -292,8 +292,8 @@ public class AceReader extends GenericDataSetReader  {
         EntityMention convertedMention = convertAceEntityMention(aceEntityMention, docId, sentence, tokenOffset, corefID);
 //        EntityMention convertedMention = convertAceEntityMention(aceEntityMention, docId, sentence, tokenOffset);
         entityCounts.incrementCount(convertedMention.getType());
-        logger.info("CONVERTED MENTION HEAD SPAN: " + convertedMention.getHead());
-        logger.info("CONVERTED ENTITY MENTION: " + convertedMention);
+        logger.finest("CONVERTED MENTION HEAD SPAN: " + convertedMention.getHead());
+        logger.finest("CONVERTED ENTITY MENTION: " + convertedMention);
         AnnotationUtils.addEntityMention(sentence, convertedMention);
         entityMentionMap.put(aceEntityMention.getId(), convertedMention);
 
@@ -305,7 +305,7 @@ public class AceReader extends GenericDataSetReader  {
         RelationMention convertedMention = convertAceRelationMention(aceRelationMention, docId, sentence, entityMentionMap);
         if(convertedMention != null){
           relationCounts.incrementCount(convertedMention.getType());
-          logger.info("CONVERTED RELATION MENTION: " + convertedMention);
+          logger.finest("CONVERTED RELATION MENTION: " + convertedMention);
           AnnotationUtils.addRelationMention(sentence, convertedMention);
         }
 
@@ -317,7 +317,7 @@ public class AceReader extends GenericDataSetReader  {
         EventMention convertedMention = convertAceEventMention(aceEventMention, docId, sentence, entityMentionMap, tokenOffset);
         if(convertedMention != null){
           eventCounts.incrementCount(convertedMention.getType());
-          logger.info("CONVERTED EVENT MENTION: " + convertedMention);
+          logger.finest("CONVERTED EVENT MENTION: " + convertedMention);
           AnnotationUtils.addEventMention(sentence, convertedMention);
         }
 

--- a/src/edu/stanford/nlp/ie/machinereading/domains/ace/reader/AceDocument.java
+++ b/src/edu/stanford/nlp/ie/machinereading/domains/ace/reader/AceDocument.java
@@ -364,7 +364,7 @@ public class AceDocument extends AceElement  {
    */
   public static AceDocument parseDocument(String prefix, boolean usePredictedBoundaries) throws java.io.IOException,
       org.xml.sax.SAXException, javax.xml.parsers.ParserConfigurationException {
-    mLog.fine("Reading document " + prefix);
+    mLog.finest("Reading document " + prefix);
     AceDocument doc = null;
 
     //
@@ -532,7 +532,7 @@ public class AceDocument extends AceElement  {
   //
   public static AceDocument parseDocument(String prefix, boolean usePredictedBoundaries, String AceVersion) throws java.io.IOException,
       org.xml.sax.SAXException, javax.xml.parsers.ParserConfigurationException {
-    mLog.fine("Reading document " + prefix);
+    mLog.finest("Reading document " + prefix);
     AceDocument doc = null;
 
     //

--- a/src/edu/stanford/nlp/ie/machinereading/domains/roth/RothCONLL04Reader.java
+++ b/src/edu/stanford/nlp/ie/machinereading/domains/roth/RothCONLL04Reader.java
@@ -48,7 +48,7 @@ public class RothCONLL04Reader extends GenericDataSetReader {
   public Annotation read(String path) throws IOException {
     Annotation doc = new Annotation("");
 
-    logger.info("Reading file: " + path);
+    logger.finest("Reading file: " + path);
 
     // Each iteration through this loop processes a single sentence along with any relations in it
     for (Iterator<String> lineIterator = IOUtils.readLines(path).iterator(); lineIterator.hasNext(); ) {

--- a/src/edu/stanford/nlp/ie/machinereading/structure/EventMention.java
+++ b/src/edu/stanford/nlp/ie/machinereading/structure/EventMention.java
@@ -161,7 +161,7 @@ public class EventMention extends RelationMention  {
           // safe to discard this arg: we already have it with the same name
           return;
         } else {
-          logger.info("Trying to add one argument: " + a + " with name " + an + " when this already exists with a different name: " + this + " in sentence: " + getSentence().get(CoreAnnotations.TextAnnotation.class));
+          logger.finest("Trying to add one argument: " + a + " with name " + an + " when this already exists with a different name: " + this + " in sentence: " + getSentence().get(CoreAnnotations.TextAnnotation.class));
           if(discardSameArgDifferentName) return;
         }
       }
@@ -200,7 +200,7 @@ public class EventMention extends RelationMention  {
     if(! type.equals(oldType)){
       // This is not important: we use anchor types in the parser, not event types
       // This is done just for completeness of code
-      logger.fine("Type changed from " + oldType + " to " + type + " during check 3 merge.");
+      logger.finest("Type changed from " + oldType + " to " + type + " during check 3 merge.");
     }
     
     // add e's arguments
@@ -209,7 +209,7 @@ public class EventMention extends RelationMention  {
       String an = e.getArgNames().get(i);
       // TODO: we might need more complex cycle detection than just contains()...
       if(a instanceof EventMention && ((EventMention) a).contains(this)){
-        logger.info("Found event cycle during merge between e1 " + this + " and e2 " + e);
+        logger.finest("Found event cycle during merge between e1 " + this + " and e2 " + e);
       } else {
         // remove e from a's parents
         if(a instanceof EventMention) ((EventMention) a).removeParent(e);

--- a/src/edu/stanford/nlp/ie/machinereading/structure/RelationMention.java
+++ b/src/edu/stanford/nlp/ie/machinereading/structure/RelationMention.java
@@ -223,7 +223,7 @@ public class RelationMention extends ExtractionObject {
   		}
   		if(newArg != null){
   			newArgs.add(newArg);
-  			logger.info("Replacing relation argument: [" + goldEnt + "] with predicted mention [" + newArg + "]");
+  			logger.finest("Replacing relation argument: [" + goldEnt + "] with predicted mention [" + newArg + "]");
   		} else {
   			/*
   			logger.info("Failed to match relation argument: " + goldEnt);
@@ -231,7 +231,7 @@ public class RelationMention extends ExtractionObject {
   			*/
   			newArgs.add(goldEnt);
   			predictedMentions.add(goldEnt);
-  			logger.info("Failed to match relation argument, so keeping gold: " + goldEnt);
+  			logger.finest("Failed to match relation argument, so keeping gold: " + goldEnt);
   		}
   	}
   	this.args = newArgs;

--- a/src/edu/stanford/nlp/ling/tokensregex/SequenceMatcher.java
+++ b/src/edu/stanford/nlp/ling/tokensregex/SequenceMatcher.java
@@ -1104,7 +1104,7 @@ public class SequenceMatcher<T> extends BasicSequenceMatchResult<T> {
         if (mg != null) {
           // This is possible if we have patterns like "( ... )+" in which case multiple nodes can match as the subgroup
           // We will match the first occurrence and use that as the subgroup  (Java uses the last match as the subgroup)
-          logger.fine("Setting matchBegin=" + curPosition + ": Capture group " + captureGroupId + " already exists: " + mg);
+          logger.finest("Setting matchBegin=" + curPosition + ": Capture group " + captureGroupId + " already exists: " + mg);
         }
         matchedGroups.put(captureGroupId, new MatchedGroup(curPosition, -1, null));
       }

--- a/src/edu/stanford/nlp/patterns/SPIEDServlet.java
+++ b/src/edu/stanford/nlp/patterns/SPIEDServlet.java
@@ -128,9 +128,9 @@ public class SPIEDServlet extends HttpServlet {
     if(model.equalsIgnoreCase("new"))
       testmode = false;
 
-    logger.info("Testmode is " + testmode);
+    logger.finest("Testmode is " + testmode);
 
-    logger.info("model is " + model);
+    logger.finest("model is " + model);
 
 
     String suggestions;
@@ -152,10 +152,10 @@ public class SPIEDServlet extends HttpServlet {
 
       String modelDir = getServletContext().getRealPath("/WEB-INF/data/"+modelNametoDirName.get(model));
       testProps.setProperty("patternsWordsDir", modelDir);
-      logger.info("Reading saved model from " + modelDir);
+      logger.finest("Reading saved model from " + modelDir);
       String seedWordsFiles="NAME,"+modelDir+"/NAME/seedwords.txt,"+modelDir+"/NAME/phrases.txt";
       String modelPropertiesFile = modelDir+"/model.properties";
-      logger.info("Loading model properties from " + modelPropertiesFile);
+      logger.finest("Loading model properties from " + modelPropertiesFile);
       String stopWordsFile = modelDir+"/stopwords.txt";
       boolean writeOutputFile = false;
       annotate.setUpProperties(jsonObject, false, writeOutputFile, seedWordsFiles);
@@ -175,7 +175,7 @@ public class SPIEDServlet extends HttpServlet {
    * {@inheritDoc}
    */
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-    logger.info("GET SPIED query from " + request.getRemoteAddr());
+    logger.finest("GET SPIED query from " + request.getRemoteAddr());
     if (request.getCharacterEncoding() == null) {
       request.setCharacterEncoding("utf-8");
     }
@@ -203,8 +203,8 @@ public class SPIEDServlet extends HttpServlet {
     StringWriter sw = new StringWriter();
     PrintWriter pw = new PrintWriter(sw);
     t.printStackTrace(pw);
-    logger.info("input is " + input);
-    logger.info(sw.toString());
+    logger.finest("input is " + input);
+    logger.finest(sw.toString());
     out.print("{\"okay\":false, \"reason\":\"Something bad happened. Contact the author.\"}");
   }
 
@@ -212,7 +212,7 @@ public class SPIEDServlet extends HttpServlet {
    * {@inheritDoc}
    */
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-    logger.info("Responding to the request for SPIED");
+    logger.finest("Responding to the request for SPIED");
     getServletContext().log("Responding through SPIED through servlet context!!");
   doGet(request, response);
 //    logger.info("POST SPIED query from " + request.getRemoteAddr());

--- a/src/edu/stanford/nlp/util/logging/JavaUtilLoggingAdaptor.java
+++ b/src/edu/stanford/nlp/util/logging/JavaUtilLoggingAdaptor.java
@@ -104,14 +104,14 @@ public class JavaUtilLoggingAdaptor {
       Logger topLogger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
       topLogger.warning("I'm warning you!");
       topLogger.severe("Now I'm using my severe voice.");
-      topLogger.info("FYI");
+      topLogger.finest("FYI");
 
       Redwood.log(Redwood.DBG, "adapting");
       JavaUtilLoggingAdaptor.adapt();
       topLogger.warning("I'm warning you in Redwood!");
       JavaUtilLoggingAdaptor.adapt(); // should be safe to call this twice
       topLogger.severe("Now I'm using my severe voice in Redwood!");
-      topLogger.info("FYI: Redwood rocks");
+      topLogger.finest("FYI: Redwood rocks");
 
       // make sure original java.util.logging levels are respected
       topLogger.setLevel(Level.OFF);
@@ -124,20 +124,20 @@ public class JavaUtilLoggingAdaptor {
       Logger topLogger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME); // Can be Logger.getGlobal() in jdk1.7
       // topLogger.addHandler(new ConsoleHandler());
       Logger logger = Logger.getLogger(JavaUtilLoggingAdaptor.class.getName());
-      topLogger.info("Starting test");
-      logger.log(Level.INFO, "Hello from the class logger");
+      topLogger.finest("Starting test");
+      logger.log(Level.FINEST, "Hello from the class logger");
 
       Redwood.log("Hello from Redwood!");
       Redwood.rootHandler().addChild(
         RedirectOutputHandler.fromJavaUtilLogging(topLogger));
       Redwood.log("Hello from Redwood -> Java!");
       Redwood.log("Hello from Redwood -> Java again!");
-      logger.log(Level.INFO, "Hello again from the class logger");
+      logger.log(Level.FINEST, "Hello again from the class logger");
       Redwood.startTrack("a track");
       Redwood.log("Inside a track");
-      logger.log(Level.INFO, "Hello a third time from the class logger");
+      logger.log(Level.FINEST, "Hello a third time from the class logger");
       Redwood.endTrack("a track");
-      logger.log(Level.INFO, "Hello a fourth time from the class logger");
+      logger.log(Level.FINEST, "Hello a fourth time from the class logger");
     }
   }
 

--- a/src/edu/stanford/nlp/util/logging/JavaUtilLoggingHandler.java
+++ b/src/edu/stanford/nlp/util/logging/JavaUtilLoggingHandler.java
@@ -30,11 +30,11 @@ public class JavaUtilLoggingHandler extends OutputHandler {
         impl.log(Level.WARNING, line);
         break;
       case DEBUG:
-        impl.log(Level.FINE, line);
+        impl.log(Level.FINEST, line);
         break;
       case STDOUT:
       case STDERR:
-        impl.info(line);
+        impl.finest(line);
         break;
       case FORCE:
         throw new IllegalStateException("Should not reach this switch case");


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. We hypothesize that portions of a system that are worked on more and more recently should have higher log levels (e.g., INFO as compared to FINEST) and vice-versa. This places event logs related to tasks that are currently more important to the forefront while pushing event logs pertaining to tasks worked on in the past to the background. The goal is to reduce information overload, bring more relevant events to developers' attention, and alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and program elements, such as edits. In this project, we calculate the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Settings

We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

1. Treat CONFIG, WARNING, and SEVERE levels as a category and not a traditional level, i.e., our tool ignores these log levels.
1. Never lower the logging level of logging statements within catch blocks.
1. Never lower the logging level of logging statements within if statements.
1. Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
1. The greatest number of commits evaluated: 6000.

The head at time of analysis was: 5fdbfb209069276e95e1765093df9855d2cf2c38