### PR TITLE
adds SpanString to named nodes for Tregex Matching

### DIFF
--- a/itest/src/edu/stanford/nlp/pipeline/SpanStringITest.java
+++ b/itest/src/edu/stanford/nlp/pipeline/SpanStringITest.java
@@ -43,4 +43,30 @@ public class SpanStringITest extends TestCase {
         String sentenceOneSpanString = document.sentences().get(0).constituencyParse().spanString();
         assertEquals(sentenceOneSpanStringGold, sentenceOneSpanString);
     }
+
+    public void testNamedSpanString() {
+        // set up pipeline properties
+        Properties props = new Properties();
+        // set the list of annotators to run
+        props.setProperty("annotators", "tokenize,ssplit,pos,lemma,parse");
+        // build pipeline
+        StanfordCoreNLP pipeline = new StanfordCoreNLP(props);
+        // create a document object
+        CoreDocument document = new CoreDocument(text);
+        // annnotate the document
+        pipeline.annotate(document);
+        List<String> foundNounPhraseStrings = new ArrayList<String>();
+        // test all of the noun phrases worked properly
+        List<String> goldNounPhraseStrings = Arrays.asList(new String[] {"The small goat", "the big mountain", "I" });
+        TregexPattern p = TregexPattern.compile("NP=np");
+        for (CoreSentence sentence : document.sentences()) {
+            TregexMatcher matcher = p.matcher(sentence.constituencyParse());
+            while (matcher.find()) {
+                for (String nodeName: matcher.getNodeNames()) {
+                    foundNounPhraseStrings.add(matcher.getNode(nodeName).spanString());
+                }
+            }
+        }
+        assertEquals(goldNounPhraseStrings, foundNounPhraseStrings);
+    }
 }

--- a/src/edu/stanford/nlp/pipeline/StanfordCoreNLPServer.java
+++ b/src/edu/stanford/nlp/pipeline/StanfordCoreNLPServer.java
@@ -1271,11 +1271,13 @@ public class StanfordCoreNLPServer implements Runnable {
                   sentWriter.set(Integer.toString(i++), (Consumer<JSONOutputter.Writer>) (JSONOutputter.Writer matchWriter) -> {
                     matchWriter.set("match", matcher.getMatch().pennString());
                     matchWriter.set("spanString", matcher.getMatch().spanString());
-                    matchWriter.set("namedNodes", matcher.getNodeNames().stream().map(nodeName -> (Consumer<JSONOutputter.Writer>) (JSONOutputter.Writer namedNodeWriter) ->
-                      namedNodeWriter.set(nodeName, matcher.getNode(nodeName).pennString())
+                    matchWriter.set("namedNodes", matcher.getNodeNames().stream().map(nodeName -> (Consumer<JSONOutputter.Writer>) (JSONOutputter.Writer namedNodeWriter) -> 
+                      namedNodeWriter.set(nodeName, (Consumer<JSONOutputter.Writer>) (JSONOutputter.Writer namedNodeSubWriter) -> {
+                        namedNodeSubWriter.set("match", matcher.getNode(nodeName).pennString());
+                        namedNodeSubWriter.set("spanString", matcher.getNode(nodeName).spanString());
+                      })
                     ));
                   });
-
                 }
             }))
           ), doc);


### PR DESCRIPTION
This commit changes the output of the server for tregex matches to provide a SpanString for each named node output

in reference to stanfordnlp/stanfordnlp#125

Note: This is a breaking change

as far as python is concerned the output should now be:

```
{'sentences': [{'0': {'match': '(NP (JJ lexical) (NNS databases))\n', 'namedNodes': [{'node1': {'match': '(NP (NNP WordNet))\n', 'spanString': 'WordNet'}}, {'node2': {'match': '(NP (JJ lexical) (NNS databases))\n', 'spanString': 'lexical databases'}}]}}]}
```

I was unable to figure out how to make the Itest I added to run