### PR TITLE
Nondeterminism in parse annotator results #938

### DIFF
--- a/src/edu/stanford/nlp/parser/dvparser/DVParserCostAndGradient.java
+++ b/src/edu/stanford/nlp/parser/dvparser/DVParserCostAndGradient.java
@@ -1,6 +1,7 @@
 package edu.stanford.nlp.parser.dvparser; 
 import edu.stanford.nlp.util.logging.Redwood;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.IdentityHashMap;
@@ -89,12 +90,12 @@ public class DVParserCostAndGradient extends AbstractCachingDiffFunction  {
       throw e;
     }
 
-    double score = 0.0;
+    BigDecimal score = new BigDecimal(0);
     for (Tree node : scores.keySet()) {
-      score += scores.get(node);
-      //log.info(Double.toString(score));
+      score = score.add(new BigDecimal(scores.get(node)));
+      //log.info(score.toString());
     }
-    return score;
+    return score.doubleValue();
   }
 
   private void forwardPropagateTree(Tree tree, List<String> words,


### PR DESCRIPTION
Fixing a floating-point-related bug, which triggered non-determinism described in #938.