### PR TITLE
Set default value of entityMentionsLanguage

### DIFF
--- a/src/edu/stanford/nlp/pipeline/EntityMentionsAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/EntityMentionsAnnotator.java
@@ -67,7 +67,7 @@ public class EntityMentionsAnnotator implements Annotator {
     // defaults
     chunkIdentifier = new LabeledChunkIdentifier();
     doAcronyms = false;
-    entityMentionsLanguage = "en";
+    entityMentionsLanguage = LanguageInfo.getLanguageFromString("en");
   }
 
   // note: used in annotate.properties

--- a/src/edu/stanford/nlp/pipeline/EntityMentionsAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/EntityMentionsAnnotator.java
@@ -67,6 +67,7 @@ public class EntityMentionsAnnotator implements Annotator {
     // defaults
     chunkIdentifier = new LabeledChunkIdentifier();
     doAcronyms = false;
+    entityMentionsLanguage = "en";
   }
 
   // note: used in annotate.properties


### PR DESCRIPTION
entityMentionsLanguage has no default at the moment when created via a no-args constructor, but is required to be non-null. This PR sets the default language to "en".