### PR TITLE
Remove unused dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,6 @@
 
     <dependency>
       <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-queries</artifactId>
-      <version>7.5.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
       <version>7.5.0</version>
     </dependency>


### PR DESCRIPTION
Hello. I noticed that dependency `org.apache.lucene:lucene-queries:7.5.0` is declared in the project's `pom` but it is not used. Hence, this dependency can be safely removed to make CoreNLP slimmer and its Maven dependency tree less complex.