### PR TITLE
Add an ExceptionAnnotation to failed annotations in StanfordCoreNLPClient

### DIFF
--- a/src/edu/stanford/nlp/pipeline/StanfordCoreNLPClient.java
+++ b/src/edu/stanford/nlp/pipeline/StanfordCoreNLPClient.java
@@ -3,6 +3,7 @@ package edu.stanford.nlp.pipeline;
 import edu.stanford.nlp.io.FileSequentialCollection;
 import edu.stanford.nlp.io.IOUtils;
 import edu.stanford.nlp.io.RuntimeIOException;
+import edu.stanford.nlp.ling.CoreAnnotations;
 import edu.stanford.nlp.util.StringUtils;
 import edu.stanford.nlp.util.logging.Redwood;
 import edu.stanford.nlp.util.logging.StanfordRedwoodConfiguration;
@@ -464,6 +465,8 @@ public class StanfordCoreNLPClient extends AnnotationPipeline  {
           log.info("Trying to annotate locally...");
           StanfordCoreNLP corenlp = new StanfordCoreNLP(properties);
           corenlp.annotate(annotation);
+        } else {
+          annotation.set(CoreAnnotations.ExceptionAnnotation.class, t);
         }
       } finally {
         callback.accept(annotation);


### PR DESCRIPTION
Should resolve https://github.com/stanfordnlp/CoreNLP/issues/991

This change allows a calling function to inspect and react to exceptions that occur when annotating using an external server. For example:

```
final Annotation annotation = new Annotation(text);

AnnotationPipeline pipeline = new StanfordCoreNLPClient(props, host, port, threads, key, secret);
pipeline.annotate(annotation);

if (annotation.containsKey(CoreAnnotations.ExceptionAnnotation.class)) {
  final Throwable t = annotation.get(CoreAnnotations.ExceptionAnnotation.class);
  throw new RuntimeException(t);
}
```

This contribution can be regarded as "de minimis" since it is less than 6 lines changed. This contribution is also in the public domain.