### PR TITLE
Use .entrySet() instead of keySet()

### DIFF
--- a/itest/src/edu/stanford/nlp/dcoref/DcorefExactOutputITest.java
+++ b/itest/src/edu/stanford/nlp/dcoref/DcorefExactOutputITest.java
@@ -4,10 +4,11 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.TreeMap;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -106,11 +107,10 @@ public class DcorefExactOutputITest {
     FileWriter fout = new FileWriter(filename);
     BufferedWriter bout = new BufferedWriter(fout);
 
-    List<Integer> keys = new ArrayList<>(chains.keySet());
-    Collections.sort(keys);
+    Map<Integer, CorefChain> sorted = new TreeMap<>(chains);
 
-    for (Integer key : keys) {
-      saveKey(bout, key, chains.get(key));
+    for (Entry<Integer, CorefChain> entry : sorted.entrySet()) {
+      saveKey(bout, entry.getKey(), entry.getValue());
     }
 
     bout.flush();
@@ -144,7 +144,7 @@ public class DcorefExactOutputITest {
 
   private static void compareResults(Map<Integer, List<ExpectedMention>> expected, Map<Integer, CorefChain> chains) {
     // Note that we don't insist on the chain ID numbers being the same
-    for (Map.Entry<Integer, List<ExpectedMention>> mapEntry : expected.entrySet()) {
+    for (Entry<Integer, List<ExpectedMention>> mapEntry : expected.entrySet()) {
       boolean found = false;
       List<ExpectedMention> expectedChain = mapEntry.getValue();
       for (CorefChain chain : chains.values()) {
@@ -156,7 +156,7 @@ public class DcorefExactOutputITest {
       Assert.assertTrue("Could not find expected coref chain " + mapEntry.getKey() + ' ' + expectedChain + " in the results", found);
     }
 
-    for (Map.Entry<Integer, CorefChain> integerCorefChainEntry : chains.entrySet()) {
+    for (Entry<Integer, CorefChain> integerCorefChainEntry : chains.entrySet()) {
       boolean found = false;
       CorefChain chain = integerCorefChainEntry.getValue();
       for (List<ExpectedMention> expectedChain : expected.values()) {

--- a/src/edu/stanford/nlp/loglinear/model/ConcatVectorNamespace.java
+++ b/src/edu/stanford/nlp/loglinear/model/ConcatVectorNamespace.java
@@ -4,6 +4,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Created on 10/20/15.
@@ -35,9 +36,9 @@ public class ConcatVectorNamespace {
    */
   public ConcatVector newWeightsVector() {
     ConcatVector vector = new ConcatVector(featureToIndex.size());
-    for (String s : sparseFeatureIndex.keySet()) {
-      int size = sparseFeatureIndex.get(s).size();
-      vector.setDenseComponent(ensureFeature(s), new double[size]);
+    for (Entry<String, Map<String, Integer>> entry : sparseFeatureIndex.entrySet()) {
+      int size = entry.getValue().size();
+      vector.setDenseComponent(ensureFeature(entry.getKey()), new double[size]);
     }
     return vector;
   }
@@ -115,10 +116,11 @@ public class ConcatVectorNamespace {
    * @param bw     the output stream to write to
    */
   public void debugVector(ConcatVector vector, BufferedWriter bw) throws IOException {
-    for (String key : featureToIndex.keySet()) {
+    for (Entry<String, Integer> entry : featureToIndex.entrySet()) {
+      String key = entry.getKey();
       bw.write(key);
       bw.write(":\n");
-      int i = featureToIndex.get(key);
+      int i = entry.getValue();
       if (vector.isComponentSparse(i)) {
         debugFeatureValue(key, vector.getSparseIndex(i), vector, bw);
       } else {

--- a/src/edu/stanford/nlp/loglinear/model/GraphicalModel.java
+++ b/src/edu/stanford/nlp/loglinear/model/GraphicalModel.java
@@ -1,12 +1,19 @@
 package edu.stanford.nlp.loglinear.model;
 
-import edu.stanford.nlp.loglinear.model.proto.GraphicalModelProto;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.function.Function;
+
+import edu.stanford.nlp.loglinear.model.proto.GraphicalModelProto;
 
 /**
  * Created on 8/7/15.
@@ -325,9 +332,9 @@ public class GraphicalModel {
 
   private static GraphicalModelProto.MetaData.Builder getProtoMetaDataBuilder(Map<String, String> metaData) {
     GraphicalModelProto.MetaData.Builder builder = GraphicalModelProto.MetaData.newBuilder();
-    for (String key : metaData.keySet()) {
-      builder.addKey(key);
-      builder.addValue(metaData.get(key));
+    for (Entry<String, String> entry : metaData.entrySet()) {
+      builder.addKey(entry.getKey());
+      builder.addValue(entry.getValue());
     }
     return builder;
   }

--- a/src/edu/stanford/nlp/maxent/Feature.java
+++ b/src/edu/stanford/nlp/maxent/Feature.java
@@ -7,12 +7,13 @@
 
 package edu.stanford.nlp.maxent;
 
+import java.io.PrintStream;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import edu.stanford.nlp.util.Generics;
 import edu.stanford.nlp.util.Index;
 import edu.stanford.nlp.util.IntPair;
-
-import java.io.PrintStream;
-import java.util.Map;
 
 
 /**
@@ -65,13 +66,16 @@ public class Feature {
         }
       }//if
     }// for
-    Integer[] keys = setNonZeros.keySet().toArray(new Integer[setNonZeros.keySet().size()]);
-    indexedValues = new int[keys.length];
-    valuesI = new double[keys.length];
-    for (int j = 0; j < keys.length; j++) {
-      indexedValues[j] = keys[j].intValue();
-      valuesI[j] = setNonZeros.get(keys[j]).doubleValue();
-    } // for
+    
+    indexedValues = new int[setNonZeros.size()];
+    valuesI = new double[indexedValues.length];
+    
+    int i = 0;
+    for (Entry<Integer, Double> entry: setNonZeros.entrySet()) {
+      indexedValues[i] = entry.getKey();
+      valuesI[i] = entry.getValue();
+      i++;
+    }
     domain = e;
   }
 

--- a/src/edu/stanford/nlp/misc/DependencyAnalyzer.java
+++ b/src/edu/stanford/nlp/misc/DependencyAnalyzer.java
@@ -1,14 +1,20 @@
 package edu.stanford.nlp.misc; 
-import edu.stanford.nlp.util.logging.Redwood;
-
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import edu.stanford.nlp.util.Generics;
+import edu.stanford.nlp.util.logging.Redwood;
 
 /**
  * Parses the output of DependencyExtractor into a tree, and constructs
@@ -298,11 +304,12 @@ public class DependencyAnalyzer  {
 
     // After reading the dependencies, as a post-processing step we
     // connect all inner classes and outer classes with each other.
-    for (String className : identifiers.keySet()) {
-      Identifier classId = identifiers.get(className);
+    for (Entry<String, Identifier> entry : identifiers.entrySet()) {
+      Identifier classId = entry.getValue();
       if (!classId.isClass) {
         continue;
       }
+      String className = entry.getKey();
       int baseIndex = className.indexOf("$");
       if (baseIndex < 0) {
         continue;

--- a/src/edu/stanford/nlp/naturalli/OpenIE.java
+++ b/src/edu/stanford/nlp/naturalli/OpenIE.java
@@ -740,7 +740,7 @@ public class OpenIE implements Annotator  {
       System.exit(1);
     }
     // Copy properties that are missing the 'openie' prefix
-    new HashSet<>(props.keySet()).stream().filter(key -> !key.toString().startsWith("openie.")).forEach(key -> props.setProperty("openie." + key.toString(), props.getProperty(key.toString())));
+    new HashMap<>(props).entrySet().stream().filter(entry -> !entry.getKey().toString().startsWith("openie.")).forEach(entry -> props.setProperty("openie." + entry.getKey(), entry.getValue().toString()));
 
     // Create the pipeline
     StanfordCoreNLP pipeline = new StanfordCoreNLP(props);

--- a/src/edu/stanford/nlp/neural/ConvertModels.java
+++ b/src/edu/stanford/nlp/neural/ConvertModels.java
@@ -8,15 +8,14 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.function.Function;
 
 import org.ejml.simple.SimpleMatrix;
 
-import edu.stanford.nlp.neural.SimpleTensor;
 import edu.stanford.nlp.parser.dvparser.DVModel;
 import edu.stanford.nlp.parser.dvparser.DVModelReranker;
-import edu.stanford.nlp.parser.dvparser.DVParser;
 import edu.stanford.nlp.parser.lexparser.LexicalizedParser;
 import edu.stanford.nlp.sentiment.RNNOptions;
 import edu.stanford.nlp.sentiment.SentimentModel;
@@ -105,8 +104,8 @@ public class ConvertModels {
 
   public static <K, V, V2> Map<K, V2> transformMap(Map<K, V> in, Function<V, V2> function) {
     Map<K, V2> transformed = Generics.newTreeMap();
-    for (K k : in.keySet()) {
-      transformed.put(k, function.apply(in.get(k)));
+    for (Entry<K, V> entry : in.entrySet()) {
+      transformed.put(entry.getKey(), function.apply(entry.getValue()));
     }
     return transformed;
   }

--- a/src/edu/stanford/nlp/neural/VectorMap.java
+++ b/src/edu/stanford/nlp/neural/VectorMap.java
@@ -1,12 +1,19 @@
 package edu.stanford.nlp.neural;
 
-import edu.stanford.nlp.io.IOUtils;
-import edu.stanford.nlp.math.ArrayMath;
-
-import java.io.*;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
+
+import edu.stanford.nlp.io.IOUtils;
+import edu.stanford.nlp.math.ArrayMath;
 
 /**
  * A serializer for reading / writing word vectors.
@@ -138,7 +145,7 @@ public class VectorMap extends HashMap<String, float[]>{
     // Write the size of the dataset
     dataOut.writeInt(this.size());
 
-    for (Map.Entry<String, float[]> entry : this.entrySet()) {
+    for (Entry<String, float[]> entry : this.entrySet()) {
       // Write the length of the key
       byte[] key = entry.getKey().getBytes();
       keyIntType.write(dataOut, key.length);
@@ -237,7 +244,7 @@ public class VectorMap extends HashMap<String, float[]>{
       try {
         Map<String, float[]> otherMap = (Map<String, float[]>) other;
         // Key sets have the same size
-        if (this.keySet().size() != otherMap.keySet().size()) {
+        if (this.size() != otherMap.size()) {
           return false;
         }
         // Entries are the same

--- a/src/edu/stanford/nlp/optimization/GoldenSectionLineSearch.java
+++ b/src/edu/stanford/nlp/optimization/GoldenSectionLineSearch.java
@@ -1,13 +1,14 @@
 package edu.stanford.nlp.optimization;
 
-import edu.stanford.nlp.util.Generics;
-import edu.stanford.nlp.util.logging.Redwood;
-
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Map;
-import java.util.Arrays;
+import java.util.Map.Entry;
+import java.util.TreeMap;
 import java.util.function.DoubleUnaryOperator;
+
+import edu.stanford.nlp.util.Generics;
+import edu.stanford.nlp.util.logging.Redwood;
 
 /**
  * A class to do golden section line search.  Should it implement Minimizer?  Prob. not.
@@ -161,10 +162,8 @@ public class GoldenSectionLineSearch implements LineSearcher  {
    * dump the {@code <x,y>} pairs it computed found
    */
   public void dumpMemory() {
-    Double[] keys = memory.keySet().toArray(new Double[memory.keySet().size()]);
-    Arrays.sort(keys);
-    for (Double key : keys) {
-      log.info(key + "\t" + memory.get(key));
+    for (Entry<Double, Double> entry : new TreeMap<>(memory).entrySet()) {
+      log.info(entry.getKey() + "\t" + entry.getValue());
     }
   }
 

--- a/src/edu/stanford/nlp/parser/dvparser/DVModel.java
+++ b/src/edu/stanford/nlp/parser/dvparser/DVModel.java
@@ -1,21 +1,22 @@
 package edu.stanford.nlp.parser.dvparser;
-import edu.stanford.nlp.util.logging.Redwood;
-
-import java.io.ObjectInputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
-import org.ejml.simple.SimpleMatrix;
 import org.ejml.data.DMatrixRMaj;
+import org.ejml.simple.SimpleMatrix;
 
+import edu.stanford.nlp.ling.Word;
 import edu.stanford.nlp.neural.Embedding;
 import edu.stanford.nlp.neural.NeuralUtils;
 import edu.stanford.nlp.parser.lexparser.BinaryGrammar;
@@ -24,12 +25,12 @@ import edu.stanford.nlp.parser.lexparser.Options;
 import edu.stanford.nlp.parser.lexparser.UnaryGrammar;
 import edu.stanford.nlp.parser.lexparser.UnaryRule;
 import edu.stanford.nlp.trees.Tree;
-import java.util.function.Function;
 import edu.stanford.nlp.util.Generics;
 import edu.stanford.nlp.util.Index;
 import edu.stanford.nlp.util.Pair;
 import edu.stanford.nlp.util.TwoDimensionalMap;
 import edu.stanford.nlp.util.TwoDimensionalSet;
+import edu.stanford.nlp.util.logging.Redwood;
 
 
 public class DVModel implements Serializable  {
@@ -462,8 +463,9 @@ public class DVModel implements Serializable  {
     //Map<String, SimpleMatrix> rawWordVectors = NeuralUtils.readRawWordVectors(op.lexOptions.wordVectorFile, op.lexOptions.numHid);
     Embedding rawWordVectors = new Embedding(op.lexOptions.wordVectorFile, op.lexOptions.numHid);
 
-    for (String word : rawWordVectors.keySet()) {
-      SimpleMatrix vector = rawWordVectors.get(word);
+    for (Entry<String, SimpleMatrix> entry : rawWordVectors.entrySet()) {
+      String word = entry.getKey();
+      SimpleMatrix vector = entry.getValue();
 
       if (op.wordFunction != null) {
         word = op.wordFunction.apply(word);

--- a/src/edu/stanford/nlp/parser/dvparser/DVParserCostAndGradient.java
+++ b/src/edu/stanford/nlp/parser/dvparser/DVParserCostAndGradient.java
@@ -91,8 +91,8 @@ public class DVParserCostAndGradient extends AbstractCachingDiffFunction  {
     }
 
     BigDecimal score = new BigDecimal(0);
-    for (Tree node : scores.keySet()) {
-      score = score.add(new BigDecimal(scores.get(node)));
+    for (Double value : scores.values()) {
+      score = score.add(new BigDecimal(value));
       //log.info(score.toString());
     }
     return score.doubleValue();

--- a/src/edu/stanford/nlp/parser/eval/TreebankFactoredLexiconStats.java
+++ b/src/edu/stanford/nlp/parser/eval/TreebankFactoredLexiconStats.java
@@ -155,16 +155,16 @@ public class TreebankFactoredLexiconStats  {
     System.out.println("Language: " + language.toString());
     System.out.printf("#trees:\t%d%n", numTrees);
     System.out.printf("#tokens:\t%d%n", (int) wordCounter.totalCount());
-    System.out.printf("#words:\t%d%n", wordCounter.keySet().size());
-    System.out.printf("#tags:\t%d%n", tagCounter.keySet().size());
-    System.out.printf("#wordTagPairs:\t%d%n", wordTagCounter.keySet().size());
-    System.out.printf("#lemmas:\t%d%n", lemmaCounter.keySet().size());
-    System.out.printf("#lemmaTagPairs:\t%d%n", lemmaTagCounter.keySet().size());
-    System.out.printf("#feattags:\t%d%n", reducedTagCounter.keySet().size());
-    System.out.printf("#feattag+lemmas:\t%d%n", reducedTagLemmaCounter.keySet().size());
-    System.out.printf("#richtags:\t%d%n", richTagCounter.keySet().size());
-    System.out.printf("#richtag+lemma:\t%d%n", morphCounter.keySet().size());
-    System.out.printf("#richtag+lemmaTagPairs:\t%d%n", morphTagCounter.keySet().size());
+    System.out.printf("#words:\t%d%n", wordCounter.size());
+    System.out.printf("#tags:\t%d%n", tagCounter.size());
+    System.out.printf("#wordTagPairs:\t%d%n", wordTagCounter.size());
+    System.out.printf("#lemmas:\t%d%n", lemmaCounter.size());
+    System.out.printf("#lemmaTagPairs:\t%d%n", lemmaTagCounter.size());
+    System.out.printf("#feattags:\t%d%n", reducedTagCounter.size());
+    System.out.printf("#feattag+lemmas:\t%d%n", reducedTagLemmaCounter.size());
+    System.out.printf("#richtags:\t%d%n", richTagCounter.size());
+    System.out.printf("#richtag+lemma:\t%d%n", morphCounter.size());
+    System.out.printf("#richtag+lemmaTagPairs:\t%d%n", morphTagCounter.size());
 
     // Extra
     System.out.println("==================");

--- a/src/edu/stanford/nlp/parser/eval/TreebankStats.java
+++ b/src/edu/stanford/nlp/parser/eval/TreebankStats.java
@@ -284,10 +284,10 @@ public class TreebankStats  {
       System.out.println("======================================================");
       System.out.println(">>> " + corpusName);
       System.out.println(" trees:\t\t" + numTrees);
-      System.out.println(" words:\t\t" + words.keySet().size());
+      System.out.println(" words:\t\t" + words.size());
       System.out.println(" tokens:\t" + (int) words.totalCount());
       System.out.println(" tags:\t\t" + posTags.size());
-      System.out.println(" phrasal types:\t" + phrasalBranchingNum2.keySet().size());
+      System.out.println(" phrasal types:\t" + phrasalBranchingNum2.size());
       System.out.println(" phrasal nodes:\t" + (int) phrasalBranchingNum2.totalCount());
       System.out.println(" OOV rate:\t" + nf.format(OOVRate * 100.0) + "%");
       System.out.println("======================================================");
@@ -362,7 +362,7 @@ public class TreebankStats  {
 
       oovWords = Generics.newHashSet(words.keySet());
       oovWords.removeAll(trainVocab);
-      OOVRate = (double) oovWords.size() / (double) words.keySet().size();
+      OOVRate = (double) oovWords.size() / (double) words.size();
     }
 
     //Corpus wide

--- a/src/edu/stanford/nlp/parser/lexparser/BaseLexicon.java
+++ b/src/edu/stanford/nlp/parser/lexparser/BaseLexicon.java
@@ -1,18 +1,4 @@
 package edu.stanford.nlp.parser.lexparser;
-import edu.stanford.nlp.util.logging.Redwood;
-
-import edu.stanford.nlp.ling.TaggedWord;
-import edu.stanford.nlp.io.NumberRangesFileFilter;
-import edu.stanford.nlp.io.EncodingPrintWriter;
-import edu.stanford.nlp.trees.Tree;
-import edu.stanford.nlp.trees.Treebank;
-import edu.stanford.nlp.trees.DiskTreebank;
-import edu.stanford.nlp.trees.TreebankLanguagePack;
-import edu.stanford.nlp.stats.ClassicCounter;
-import edu.stanford.nlp.stats.Counter;
-import edu.stanford.nlp.stats.Counters;
-import edu.stanford.nlp.util.*;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -20,10 +6,35 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.text.NumberFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import edu.stanford.nlp.io.EncodingPrintWriter;
+import edu.stanford.nlp.io.NumberRangesFileFilter;
+import edu.stanford.nlp.ling.TaggedWord;
+import edu.stanford.nlp.stats.ClassicCounter;
+import edu.stanford.nlp.stats.Counter;
+import edu.stanford.nlp.stats.Counters;
+import edu.stanford.nlp.trees.DiskTreebank;
+import edu.stanford.nlp.trees.Tree;
+import edu.stanford.nlp.trees.Treebank;
+import edu.stanford.nlp.trees.TreebankLanguagePack;
+import edu.stanford.nlp.util.Generics;
+import edu.stanford.nlp.util.HashIndex;
+import edu.stanford.nlp.util.Index;
+import edu.stanford.nlp.util.ReflectionLoading;
+import edu.stanford.nlp.util.StringUtils;
+import edu.stanford.nlp.util.logging.Redwood;
 
 
 /**
@@ -411,9 +422,9 @@ public class BaseLexicon implements Lexicon  {
         ++loc;
         continue;
       }
-      for (String tag : counts.keySet()) {
-        TaggedWord newTW = new TaggedWord(tw.word(), tag);
-        train(newTW, loc, weight * counts.getCount(tag) / totalCount);
+      for (Entry<String, Double> entry : counts.entrySet()) {
+        TaggedWord newTW = new TaggedWord(tw.word(), entry.getKey());
+        train(newTW, loc, weight * entry.getValue() / totalCount);
       }
       ++loc;
     }
@@ -787,11 +798,11 @@ public class BaseLexicon implements Lexicon  {
   public void writeData(Writer w) throws IOException {
     PrintWriter out = new PrintWriter(w);
 
-    for (IntTaggedWord itw : seenCounter.keySet()) {
-      out.println(itw.toLexicalEntry(wordIndex, tagIndex) + " SEEN " + seenCounter.getCount(itw));
+    for (Entry<IntTaggedWord, Double> entry : seenCounter.entrySet()) {
+      out.println(entry.getKey().toLexicalEntry(wordIndex, tagIndex) + " SEEN " + entry.getValue());
     }
-    for (IntTaggedWord itw : getUnknownWordModel().unSeenCounter().keySet()) {
-      out.println(itw.toLexicalEntry(wordIndex, tagIndex) + " UNSEEN " + getUnknownWordModel().unSeenCounter().getCount(itw));
+    for (Entry<IntTaggedWord, Double> entry : getUnknownWordModel().unSeenCounter().entrySet()) {
+      out.println(entry.getKey().toLexicalEntry(wordIndex, tagIndex) + " UNSEEN " + entry.getValue());
     }
     for (int i = 0; i < smooth.length; i++) {
       out.println("smooth[" + i + "] = " + smooth[i]);

--- a/src/edu/stanford/nlp/parser/lexparser/BaseUnknownWordModelTrainer.java
+++ b/src/edu/stanford/nlp/parser/lexparser/BaseUnknownWordModelTrainer.java
@@ -1,7 +1,6 @@
 package edu.stanford.nlp.parser.lexparser; 
-import edu.stanford.nlp.util.logging.Redwood;
-
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import edu.stanford.nlp.ling.Label;
@@ -10,6 +9,7 @@ import edu.stanford.nlp.ling.TaggedWord;
 import edu.stanford.nlp.stats.ClassicCounter;
 import edu.stanford.nlp.util.Generics;
 import edu.stanford.nlp.util.Index;
+import edu.stanford.nlp.util.logging.Redwood;
 
 public class BaseUnknownWordModelTrainer
   extends AbstractUnknownWordModelTrainer
@@ -134,8 +134,9 @@ public class BaseUnknownWordModelTrainer
       wc.setCount(unknown, 1.0);
 
       /* inner iteration is over words */
-      for (String end : wc.keySet()) {
-        double prob = Math.log((wc.getCount(end)) / (tc.getCount(key)));  // p(sig|tag)
+      for (Entry<String, Double> wEntry : wc.entrySet()) {
+        String end = wEntry.getKey();
+        double prob = Math.log(wEntry.getValue() / tc.getCount(key));  // p(sig|tag)
         tagHash.get(key).setCount(end, prob);
         //if (Test.verbose)
         //EncodingPrintWriter.out.println(tag + " rewrites as " + end + " endchar with probability " + prob,encoding);


### PR DESCRIPTION
This way, it is faster, since map is searched for an entry only not, and not twice (one for key and another for value).

This PR is initially for discussing the change, then it would be followed by other commits/PRs to cover the whole code.

P.S.: I wonder if making `edu.stanford.nlp.stats.Counter` a `Map` would add a value. 