### PR TITLE
Fix travis build (mvn install)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ install:
 # download models (see `README.md`)
 - wget http://nlp.stanford.edu/software/stanford-corenlp-models-current.jar
 - wget http://nlp.stanford.edu/software/stanford-english-corenlp-models-current.jar
-- mvn install:install-file -Dfile=stanford-corenlp-models-current.jar -DgroupId=edu.stanford.nlp -DartifactId=stanford-corenlp -Dversion=3.9.2 -Dclassifier=models -Dpackaging=jar
-- mvn install:install-file -Dfile=stanford-english-corenlp-models-current.jar -DgroupId=edu.stanford.nlp -DartifactId=stanford-corenlp -Dversion=3.9.2 -Dclassifier=models-english -Dpackaging=jar
+- mvn install:install-file -Dfile=stanford-corenlp-models-current.jar -DgroupId=edu.stanford.nlp -DartifactId=stanford-corenlp -Dversion=4.0.0 -Dclassifier=models -Dpackaging=jar
+- mvn install:install-file -Dfile=stanford-english-corenlp-models-current.jar -DgroupId=edu.stanford.nlp -DartifactId=stanford-corenlp -Dversion=4.0.0 -Dclassifier=models-english -Dpackaging=jar
 
-- mv stanford-corenlp-models-current.jar stanford-corenlp-3.9.2-models.jar
+- mv stanford-corenlp-models-current.jar stanford-corenlp-4.0.0-models.jar
 # necessary for `mvn install`
 
 script:


### PR DESCRIPTION
It seems that the [master](https://github.com/stanfordnlp/CoreNLP/commits/master) is currently not successfully built on travis.
I think the version of the project was updated in `pom.xml` and the jar was deployed, however `travis.yml` still uses the old v3.9.2 causing it to fail during `mvn install`.