### PR TITLE
Use ClassLoader.getSystemResourceAsStream(name) for loading models

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,9 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'application'
-
+apply plugin: 'maven'
+    
+group = 'com.github.ICIJ'
 // Gradle java plugin
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/edu/stanford/nlp/io/IOUtils.java
+++ b/src/edu/stanford/nlp/io/IOUtils.java
@@ -415,7 +415,7 @@ public class IOUtils  {
     // ms 10-04-2010:
     // - even though this may look like a regular file, it may be a path inside a jar in the CLASSPATH
     // - check for this first. This takes precedence over the file system.
-    InputStream is = IOUtils.class.getClassLoader().getResourceAsStream(name);
+    InputStream is = ClassLoader.getSystemResourceAsStream(name);
     // windows File.separator is \, but getting resources only works with /
     if (is == null) {
       is = IOUtils.class.getClassLoader().getResourceAsStream(name.replaceAll("\\\\", "/"));
@@ -438,7 +438,7 @@ public class IOUtils  {
    * @return true if a call to {@link IOUtils#getBufferedReaderFromClasspathOrFileSystem(String)} would return a valid stream.
    */
   public static boolean existsInClasspathOrFileSystem(String name) {
-    InputStream is = IOUtils.class.getClassLoader().getResourceAsStream(name);
+    InputStream is = ClassLoader.getSystemResourceAsStream(name);
     if (is == null) {
       is = IOUtils.class.getClassLoader().getResourceAsStream(name.replaceAll("\\\\", "/"));
       if (is == null) {


### PR DESCRIPTION
instead of     
```
IOUtils.class.getClassLoader().getResourceAsStream(name);
```

As the NLP pipelines are diverse and provide different results, we made them loadable as plugins. So we are using dynamic class loading using a [DynamicClassLoader](https://stackoverflow.com/a/59743937/396155) and setting the property `java.system.class.loader` to it.

The problem is that we have now a hierarchy of 3 class loaders : 
```
sun.misc.Launcher$ExtClassLoader
                       |
sun.misc.Launcher$AppClassLoader
                       |
org.icij.datashare.DynamicClassLoader
```
`IOUtils.class.getClassLoader()` is returning `AppClassLoader` but the models are visible in the ̀`DynamicClassLoader` via the class path of the application.

ClassLoaders can see the parents resources but cannot see the children resources. 

Would it be possible to use the system class loader to load models instead of IOUtils class loader ?

I don't see any drawbacks of it but maybe I'm missing something.

Thank you.