### PR TITLE
Fix sr binary

### DIFF
--- a/src/edu/stanford/nlp/parser/shiftreduce/BaseModel.java
+++ b/src/edu/stanford/nlp/parser/shiftreduce/BaseModel.java
@@ -15,18 +15,14 @@ import edu.stanford.nlp.util.ErasureUtils;
 import edu.stanford.nlp.util.Index;
 import edu.stanford.nlp.util.ScoredObject;
 
-// TODO: remove when models are rebuilt
-import java.io.*;
-import edu.stanford.nlp.util.HashIndex;
-
 public abstract class BaseModel implements Serializable {
 
-  /*final*/ ShiftReduceOptions op;
+  final ShiftReduceOptions op;
 
-  /*final*/ Index<Transition> transitionIndex;
-  /*final*/ Set<String> knownStates; // the set of goal categories of a reduce = the set of phrasal categories in a grammar
-  /*final*/ Set<String> rootStates;
-  /*final*/ Set<String> rootOnlyStates;
+  final Index<Transition> transitionIndex;
+  final Set<String> knownStates; // the set of goal categories of a reduce = the set of phrasal categories in a grammar
+  final Set<String> rootStates;
+  final Set<String> rootOnlyStates;
 
   public BaseModel(ShiftReduceOptions op, Index<Transition> transitionIndex,
                    Set<String> knownStates, Set<String> rootStates, Set<String> rootOnlyStates) {
@@ -48,7 +44,10 @@ public abstract class BaseModel implements Serializable {
     this.rootOnlyStates = other.rootOnlyStates;
   }
 
-  // TODO: get rid of this when the models are rebuilt
+  /*
+  // This chunk of code can read a model where the BinaryTransitions
+  // aren't protected from going to root in the middle of a tree and
+  // fix those models so that can't happen
   private void readObject(ObjectInputStream in)
     throws IOException, ClassNotFoundException
   {
@@ -68,9 +67,13 @@ public abstract class BaseModel implements Serializable {
       BinaryTransition bt = (BinaryTransition) t;
       boolean isRoot = ((bt.isBinarized() && rootOnlyStates.contains(bt.label.substring(1))) ||
                         rootOnlyStates.contains(bt.label));
+      if (isRoot) {
+        System.out.println("Updating a transition: " + bt);
+      }
       transitionIndex.add(new BinaryTransition(bt.label, bt.side, isRoot));
     }
   }
+  */
   
   /**
    * Returns a transition which might not even be part of the model,

--- a/src/edu/stanford/nlp/parser/shiftreduce/BinaryTransition.java
+++ b/src/edu/stanford/nlp/parser/shiftreduce/BinaryTransition.java
@@ -18,13 +18,17 @@ public class BinaryTransition implements Transition {
   /** Which side the head is on */
   public final Side side;
 
+  /** root transitions are illegal in the middle of the tree, naturally */
+  public final boolean isRoot;
+
   public enum Side {
     LEFT, RIGHT
   }
 
-  public BinaryTransition(String label, Side side) {
+  public BinaryTransition(String label, Side side, boolean isRoot) {
     this.label = label;
     this.side = side;
+    this.isRoot = isRoot;
   }
 
   /**
@@ -79,6 +83,19 @@ public class BinaryTransition implements Transition {
     // from binary reduce must be left-headed
     if (state.stack.size() > 2 && ShiftReduceUtils.isTemporary(state.stack.pop().pop().peek()) && isBinarized() && side == Side.RIGHT) {
       return false;
+    }
+
+    // if this transition is only allowed at the root node, and the
+    // model tries to apply it elsewhere, that must be rejected unless
+    // the transition is a temporary aka "binarized" transition
+    if (isRoot && !isBinarized()) {
+      if (state.stack.size() > 2) {
+        // stuff to the left
+        return false;
+      } else if (state.stack.size() == 2 && !state.endOfQueue()) {
+        // stuff to the right
+        return false;
+      }
     }
 
     if (constraints == null) {
@@ -218,9 +235,9 @@ public class BinaryTransition implements Transition {
   public String toString() {
     switch(side) {
     case LEFT:
-      return "LeftBinary(" + label + ")";
+      return "LeftBinary" + (isRoot ? "*" : "") + "(" + label + ")";
     case RIGHT:
-      return "RightBinary(" + label + ")";
+      return "RightBinary" + (isRoot ? "*" : "") + "(" + label + ")";
     default:
       throw new IllegalArgumentException("Unknown side " + side);
     }

--- a/src/edu/stanford/nlp/parser/shiftreduce/CreateTransitionSequence.java
+++ b/src/edu/stanford/nlp/parser/shiftreduce/CreateTransitionSequence.java
@@ -79,10 +79,11 @@ public class CreateTransitionSequence {
       if (head == null || leftHead == null || rightHead == null) {
         throw new IllegalArgumentException("Expected tree labels to have their heads assigned.  Failed at: " + tree);
       }
+      boolean isRoot = rootOnlyStates.contains(tree.label().value());
       if (head == leftHead) {
-        transitions.add(new BinaryTransition(tree.label().value(), BinaryTransition.Side.LEFT));
+        transitions.add(new BinaryTransition(tree.label().value(), BinaryTransition.Side.LEFT, isRoot));
       } else if (head == rightHead) {
-        transitions.add(new BinaryTransition(tree.label().value(), BinaryTransition.Side.RIGHT));
+        transitions.add(new BinaryTransition(tree.label().value(), BinaryTransition.Side.RIGHT, isRoot));
       } else {
         throw new IllegalArgumentException("Heads were incorrectly assigned: tree's head is not matched to either the right or left head");
       }

--- a/src/edu/stanford/nlp/parser/shiftreduce/Oracle.java
+++ b/src/edu/stanford/nlp/parser/shiftreduce/Oracle.java
@@ -35,7 +35,9 @@ class Oracle {
 
   final Set<String> rootStates;
 
-  Oracle(List<Tree> binarizedTrees, boolean compoundUnaries, Set<String> rootStates) {
+  final Set<String> rootOnlyStates;
+
+  Oracle(List<Tree> binarizedTrees, boolean compoundUnaries, Set<String> rootStates, Set<String> rootOnlyStates) {
     this.binarizedTrees = binarizedTrees;
 
     parentMaps = Generics.newArrayList(binarizedTrees.size());
@@ -47,6 +49,7 @@ class Oracle {
 
     this.compoundUnaries = compoundUnaries;
     this.rootStates = rootStates;
+    this.rootOnlyStates = rootOnlyStates;
   }
 
   static IdentityHashMap<Tree, Tree> buildParentMap(Tree tree) {
@@ -158,7 +161,7 @@ class Oracle {
       Tree enclosingS1 = getEnclosingTree(S1, parents, leaves);
       if (spansEqual(S1, enclosingS1)) {
         // the two subtrees should be combined
-        return new OracleTransition(new BinaryTransition(parent.value(), ShiftReduceUtils.getBinarySide(parent)), false, false, false);
+        return new OracleTransition(new BinaryTransition(parent.value(), ShiftReduceUtils.getBinarySide(parent), rootOnlyStates.contains(parent.value())), false, false, false);
       }
       return new OracleTransition(null, false, true, false);
     }
@@ -170,7 +173,7 @@ class Oracle {
       Tree enclosingS1 = getEnclosingTree(S1, parents, leaves);
       if (enclosingS0 == enclosingS1) {
         // BinaryTransition with enclosingS0's label, either side, but preferring LEFT
-        return new OracleTransition(new BinaryTransition(enclosingS0.value(), BinaryTransition.Side.LEFT), false, false, true);
+        return new OracleTransition(new BinaryTransition(enclosingS0.value(), BinaryTransition.Side.LEFT, rootOnlyStates.contains(enclosingS0.value())), false, false, true);
       }
       // S1 is smaller than the next tree S0 is supposed to be part of,
       // so we must have a BinaryTransition

--- a/src/edu/stanford/nlp/parser/shiftreduce/PerceptronModel.java
+++ b/src/edu/stanford/nlp/parser/shiftreduce/PerceptronModel.java
@@ -256,7 +256,7 @@ public class PerceptronModel extends BaseModel  {
     ReorderingOracle reorderer = null;
     if (op.trainOptions().trainingMethod == ShiftReduceTrainOptions.TrainingMethod.REORDER_ORACLE ||
         op.trainOptions().trainingMethod == ShiftReduceTrainOptions.TrainingMethod.REORDER_BEAM) {
-      reorderer = new ReorderingOracle(op);
+      reorderer = new ReorderingOracle(op, rootOnlyStates);
     }
 
     // TODO.  This training method seems to be working in that it
@@ -510,7 +510,7 @@ public class PerceptronModel extends BaseModel  {
 
     Oracle oracle = null;
     if (op.trainOptions().trainingMethod == ShiftReduceTrainOptions.TrainingMethod.ORACLE) {
-      oracle = new Oracle(binarizedTrees, op.compoundUnaries, rootStates);
+      oracle = new Oracle(binarizedTrees, op.compoundUnaries, rootStates, rootOnlyStates);
     }
 
     List<Update> updates = Generics.newArrayList();

--- a/src/edu/stanford/nlp/parser/shiftreduce/ReorderingOracle.java
+++ b/src/edu/stanford/nlp/parser/shiftreduce/ReorderingOracle.java
@@ -2,6 +2,7 @@ package edu.stanford.nlp.parser.shiftreduce;
 
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Set;
 
 import edu.stanford.nlp.util.Generics;
 
@@ -14,10 +15,13 @@ import edu.stanford.nlp.util.Generics;
  * @author John Bauer
  */
 public class ReorderingOracle {
-  ShiftReduceOptions op;
+  final ShiftReduceOptions op;
 
-  public ReorderingOracle(ShiftReduceOptions op) {
+  final Set<String> rootOnlyStates;
+
+  public ReorderingOracle(ShiftReduceOptions op, Set<String> rootOnlyStates) {
     this.op = op;
+    this.rootOnlyStates = rootOnlyStates;
   }
 
   /**
@@ -115,7 +119,7 @@ public class ReorderingOracle {
     return false;
   }
 
-  static boolean reorderIncorrectBinaryTransition(List<Transition> transitions) {
+  boolean reorderIncorrectBinaryTransition(List<Transition> transitions) {
     int shiftCount = 0;
     ListIterator<Transition> cursor = transitions.listIterator();
     do {
@@ -164,7 +168,7 @@ public class ReorderingOracle {
    * Sadly, this does not seem to help - the parser gets worse when it
    * learns these states
    */
-  static boolean reorderIncorrectShiftTransition(List<Transition> transitions) {
+  boolean reorderIncorrectShiftTransition(List<Transition> transitions) {
     List<BinaryTransition> leftoverBinary = Generics.newArrayList();
     while (transitions.size() > 0) {
       Transition head = transitions.remove(0);
@@ -213,16 +217,16 @@ public class ReorderingOracle {
       // we add a bunch of temporary binary transitions with a right
       // head, ending up with a binary transition with a right head
       for (int i = 0; i < leftoverBinary.size(); ++i) {
-        cursor.add(new BinaryTransition("@" + label, BinaryTransition.Side.RIGHT));
+        cursor.add(new BinaryTransition("@" + label, BinaryTransition.Side.RIGHT, rootOnlyStates.contains(label)));
       }
       // use lastBinary.label in case the last transition is temporary
-      cursor.add(new BinaryTransition(lastBinary.label, BinaryTransition.Side.RIGHT));
+      cursor.add(new BinaryTransition(lastBinary.label, BinaryTransition.Side.RIGHT, rootOnlyStates.contains(label)));
     } else {
-      cursor.add(new BinaryTransition("@" + label, BinaryTransition.Side.LEFT));
+      cursor.add(new BinaryTransition("@" + label, BinaryTransition.Side.LEFT, rootOnlyStates.contains(label)));
       for (int i = 0; i < leftoverBinary.size() - 1; ++i) {
-        cursor.add(new BinaryTransition("@" + label, leftoverBinary.get(i).side));
+        cursor.add(new BinaryTransition("@" + label, leftoverBinary.get(i).side, rootOnlyStates.contains(label)));
       }
-      cursor.add(new BinaryTransition(lastBinary.label, leftoverBinary.get(leftoverBinary.size() - 1).side));
+      cursor.add(new BinaryTransition(lastBinary.label, leftoverBinary.get(leftoverBinary.size() - 1).side, rootOnlyStates.contains(lastBinary.label)));
     }
     return true;
   }

--- a/test/src/edu/stanford/nlp/parser/shiftreduce/BinaryTransitionTest.java
+++ b/test/src/edu/stanford/nlp/parser/shiftreduce/BinaryTransitionTest.java
@@ -38,7 +38,7 @@ public class BinaryTransitionTest extends TestCase {
 
   public void testLeftTransition() {
     State state = buildState(2);
-    BinaryTransition transition = new BinaryTransition("NP", BinaryTransition.Side.LEFT);
+    BinaryTransition transition = new BinaryTransition("NP", BinaryTransition.Side.LEFT, false);
     state = transition.apply(state);
     assertEquals(2, state.tokenPosition);
     assertEquals(1, state.stack.size());
@@ -49,7 +49,7 @@ public class BinaryTransitionTest extends TestCase {
 
   public void testRightTransition() {
     State state = buildState(2);
-    BinaryTransition transition = new BinaryTransition("NP", BinaryTransition.Side.RIGHT);
+    BinaryTransition transition = new BinaryTransition("NP", BinaryTransition.Side.RIGHT, false);
     state = transition.apply(state);
     assertEquals(2, state.tokenPosition);
     assertEquals(1, state.stack.size());

--- a/test/src/edu/stanford/nlp/parser/shiftreduce/OracleTest.java
+++ b/test/src/edu/stanford/nlp/parser/shiftreduce/OracleTest.java
@@ -51,13 +51,13 @@ public class OracleTest extends TestCase {
    */
   public void testEndToEndCompoundUnaries() {
     List<Tree> binarizedTrees = buildTestTreebank();
-    Oracle oracle = new Oracle(binarizedTrees, true, Collections.singleton("ROOT"));
+    Oracle oracle = new Oracle(binarizedTrees, true, Collections.singleton("ROOT"), Collections.singleton("ROOT"));
     runEndToEndTest(binarizedTrees, oracle);
   }
 
   public void testEndToEndSingleUnaries() {
     List<Tree> binarizedTrees = buildTestTreebank();
-    Oracle oracle = new Oracle(binarizedTrees, false, Collections.singleton("ROOT"));
+    Oracle oracle = new Oracle(binarizedTrees, false, Collections.singleton("ROOT"), Collections.singleton("ROOT"));
     runEndToEndTest(binarizedTrees, oracle);
   }
 

--- a/test/src/edu/stanford/nlp/parser/shiftreduce/ReorderingOracleTest.java
+++ b/test/src/edu/stanford/nlp/parser/shiftreduce/ReorderingOracleTest.java
@@ -24,20 +24,20 @@ public class ReorderingOracleTest extends TestCase {
   FinalizeTransition finalize = new FinalizeTransition(Collections.singleton("ROOT"));
   ShiftTransition shift = new ShiftTransition();
 
-  BinaryTransition rightNP = new BinaryTransition("NP", BinaryTransition.Side.RIGHT);
-  BinaryTransition tempRightNP = new BinaryTransition("@NP", BinaryTransition.Side.RIGHT);
-  BinaryTransition leftNP = new BinaryTransition("NP", BinaryTransition.Side.LEFT);
-  BinaryTransition tempLeftNP = new BinaryTransition("@NP", BinaryTransition.Side.LEFT);
+  BinaryTransition rightNP = new BinaryTransition("NP", BinaryTransition.Side.RIGHT, false);
+  BinaryTransition tempRightNP = new BinaryTransition("@NP", BinaryTransition.Side.RIGHT, false);
+  BinaryTransition leftNP = new BinaryTransition("NP", BinaryTransition.Side.LEFT, false);
+  BinaryTransition tempLeftNP = new BinaryTransition("@NP", BinaryTransition.Side.LEFT, false);
 
-  BinaryTransition rightVP = new BinaryTransition("VP", BinaryTransition.Side.RIGHT);
-  BinaryTransition tempRightVP = new BinaryTransition("@VP", BinaryTransition.Side.RIGHT);
-  BinaryTransition leftVP = new BinaryTransition("VP", BinaryTransition.Side.LEFT);
-  BinaryTransition tempLeftVP = new BinaryTransition("@VP", BinaryTransition.Side.LEFT);
+  BinaryTransition rightVP = new BinaryTransition("VP", BinaryTransition.Side.RIGHT, false);
+  BinaryTransition tempRightVP = new BinaryTransition("@VP", BinaryTransition.Side.RIGHT, false);
+  BinaryTransition leftVP = new BinaryTransition("VP", BinaryTransition.Side.LEFT, false);
+  BinaryTransition tempLeftVP = new BinaryTransition("@VP", BinaryTransition.Side.LEFT, false);
 
-  BinaryTransition rightS = new BinaryTransition("S", BinaryTransition.Side.RIGHT);
-  BinaryTransition tempRightS = new BinaryTransition("@S", BinaryTransition.Side.RIGHT);
-  BinaryTransition leftS = new BinaryTransition("S", BinaryTransition.Side.LEFT);
-  BinaryTransition tempLeftS = new BinaryTransition("@S", BinaryTransition.Side.LEFT);
+  BinaryTransition rightS = new BinaryTransition("S", BinaryTransition.Side.RIGHT, false);
+  BinaryTransition tempRightS = new BinaryTransition("@S", BinaryTransition.Side.RIGHT, false);
+  BinaryTransition leftS = new BinaryTransition("S", BinaryTransition.Side.LEFT, false);
+  BinaryTransition tempLeftS = new BinaryTransition("@S", BinaryTransition.Side.LEFT, false);
 
   UnaryTransition unaryADVP = new UnaryTransition("ADVP", false);
 
@@ -52,6 +52,8 @@ public class ReorderingOracleTest extends TestCase {
   };
   List<Tree> binarizedTrees; // initialized in setUp
 
+  ReorderingOracle oracle = new ReorderingOracle(new ShiftReduceOptions(), Collections.singleton("ROOT"));
+  
   Tree[] incorrectShiftTrees = { 
     Tree.valueOf("(ROOT (S (PRP$ My) (NN dog) (ADVP (RB also)) (VP (VBZ likes) (S (VP (VBG eating) (NP (NN sausage))))) (. .)))"),
     Tree.valueOf("(NP (NN A) (NN B) (NN C))") , // doesn't have to make sense
@@ -74,15 +76,15 @@ public class ReorderingOracleTest extends TestCase {
 
   public void testReorderIncorrectBinaryTransition() {
     List<Transition> transitions = buildTransitionList(shift, rightNP, rightVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectBinaryTransition(transitions));
+    assertTrue(oracle.reorderIncorrectBinaryTransition(transitions));
     assertEquals(buildTransitionList(shift, rightVP, finalize), transitions);
 
     transitions = buildTransitionList(shift, unaryADVP, rightNP, rightVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectBinaryTransition(transitions));
+    assertTrue(oracle.reorderIncorrectBinaryTransition(transitions));
     assertEquals(buildTransitionList(shift, unaryADVP, rightVP, finalize), transitions);    
 
     transitions = buildTransitionList(shift, rightNP, unaryADVP, rightVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectBinaryTransition(transitions));
+    assertTrue(oracle.reorderIncorrectBinaryTransition(transitions));
     assertEquals(buildTransitionList(shift, rightVP, finalize), transitions);    
   }
 
@@ -102,7 +104,7 @@ public class ReorderingOracleTest extends TestCase {
       }
       state = shift.apply(state);
       List<Transition> reordered = Generics.newLinkedList(gold.subList(tnum, gold.size()));
-      assertTrue(ReorderingOracle.reorderIncorrectShiftTransition(reordered));
+      assertTrue(oracle.reorderIncorrectShiftTransition(reordered));
       // System.err.println(reordered);
       for (Transition transition : reordered) {
         state = transition.apply(state);
@@ -115,43 +117,43 @@ public class ReorderingOracleTest extends TestCase {
 
   public void testReorderIncorrectShift() {
     List<Transition> transitions = buildTransitionList(rightNP, shift, rightVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectShiftTransition(transitions));
+    assertTrue(oracle.reorderIncorrectShiftTransition(transitions));
     assertEquals(buildTransitionList(tempRightVP, rightVP, finalize), transitions);
 
     transitions = buildTransitionList(rightNP, shift, shift, leftNP, rightVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectShiftTransition(transitions));
+    assertTrue(oracle.reorderIncorrectShiftTransition(transitions));
     assertEquals(buildTransitionList(shift, leftNP, tempRightVP, rightVP, finalize), transitions);
 
     transitions = buildTransitionList(rightNP, shift, unaryADVP, shift, leftNP, rightVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectShiftTransition(transitions));
+    assertTrue(oracle.reorderIncorrectShiftTransition(transitions));
     assertEquals(buildTransitionList(unaryADVP, shift, leftNP, tempRightVP, rightVP, finalize), transitions);
 
     transitions = buildTransitionList(rightNP, shift, shift, unaryADVP, leftNP, rightVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectShiftTransition(transitions));
+    assertTrue(oracle.reorderIncorrectShiftTransition(transitions));
     assertEquals(buildTransitionList(shift, unaryADVP, leftNP, tempRightVP, rightVP, finalize), transitions);
 
     transitions = buildTransitionList(leftNP, shift, shift, unaryADVP, leftNP, rightVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectShiftTransition(transitions));
+    assertTrue(oracle.reorderIncorrectShiftTransition(transitions));
     assertEquals(buildTransitionList(shift, unaryADVP, leftNP, tempRightVP, rightVP, finalize), transitions);
 
     transitions = buildTransitionList(leftNP, shift, shift, unaryADVP, leftNP, leftVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectShiftTransition(transitions));
+    assertTrue(oracle.reorderIncorrectShiftTransition(transitions));
     assertEquals(buildTransitionList(shift, unaryADVP, leftNP, tempLeftVP, leftVP, finalize), transitions);
 
     transitions = buildTransitionList(rightNP, shift, shift, unaryADVP, leftNP, leftVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectShiftTransition(transitions));
+    assertTrue(oracle.reorderIncorrectShiftTransition(transitions));
     assertEquals(buildTransitionList(shift, unaryADVP, leftNP, tempLeftVP, rightVP, finalize), transitions);
 
     transitions = buildTransitionList(leftNP, leftNP, shift, shift, unaryADVP, leftNP, rightVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectShiftTransition(transitions));
+    assertTrue(oracle.reorderIncorrectShiftTransition(transitions));
     assertEquals(buildTransitionList(shift, unaryADVP, leftNP, tempRightVP, tempRightVP, rightVP, finalize), transitions);
 
     transitions = buildTransitionList(leftNP, rightNP, shift, shift, unaryADVP, leftNP, leftVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectShiftTransition(transitions));
+    assertTrue(oracle.reorderIncorrectShiftTransition(transitions));
     assertEquals(buildTransitionList(shift, unaryADVP, leftNP, tempLeftVP, tempLeftVP, rightVP, finalize), transitions);
 
     transitions = buildTransitionList(leftNP, leftNP, shift, shift, unaryADVP, leftNP, leftVP, finalize);
-    assertTrue(ReorderingOracle.reorderIncorrectShiftTransition(transitions));
+    assertTrue(oracle.reorderIncorrectShiftTransition(transitions));
     assertEquals(buildTransitionList(shift, unaryADVP, leftNP, tempLeftVP, tempLeftVP, leftVP, finalize), transitions);
   }
 }

--- a/test/src/edu/stanford/nlp/parser/shiftreduce/ShiftReduceUtilsTest.java
+++ b/test/src/edu/stanford/nlp/parser/shiftreduce/ShiftReduceUtilsTest.java
@@ -21,11 +21,11 @@ public class ShiftReduceUtilsTest extends TestCase {
     ShiftTransition shift = new ShiftTransition();
     state = shift.apply(shift.apply(state));
 
-    BinaryTransition transition = new BinaryTransition("NP", BinaryTransition.Side.RIGHT);
+    BinaryTransition transition = new BinaryTransition("NP", BinaryTransition.Side.RIGHT, false);
     State next = transition.apply(state);
     assertEquals(BinaryTransition.Side.RIGHT, ShiftReduceUtils.getBinarySide(next.stack.peek()));
 
-    transition = new BinaryTransition("NP", BinaryTransition.Side.LEFT);
+    transition = new BinaryTransition("NP", BinaryTransition.Side.LEFT, false);
     next = transition.apply(state);
     assertEquals(BinaryTransition.Side.LEFT, ShiftReduceUtils.getBinarySide(next.stack.peek()));
   }


### PR DESCRIPTION
Fix a bug in which the parser might accidentally learn to transition to ROOT as a binary transition, so now we prevent that from happening in the middle of a tree