### PR TITLE
Increase scripts/lexparser/lexparser.sh mem usage to 200m

### DIFF
--- a/scripts/lexparser/lexparser.sh
+++ b/scripts/lexparser/lexparser.sh
@@ -10,5 +10,5 @@ fi
 
 scriptdir=`dirname $0`
 
-java -mx150m -cp "$scriptdir/*:" edu.stanford.nlp.parser.lexparser.LexicalizedParser \
+java -mx200m -cp "$scriptdir/*:" edu.stanford.nlp.parser.lexparser.LexicalizedParser \
  -outputFormat "penn,typedDependencies" edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz $*


### PR DESCRIPTION
- While running the standalone parser 4.2.0 from https://stanfordnlp.github.io/CoreNLP/parser-standalone.html I noticed it crashing with test data included in `libexec/data/testsent.txt` with an out of memory exception. Increasing the value from 150m to 170m worked just fine for the test data. Set it to 200m in this patch for good measure.

- The 150m setting also causes test failures when trying to install via homebrew on mac, which runs the included `testsent.txt` file. I discovered this initially when creating a PR to bump the version to 4.2.0 for homebrew.