### PR TITLE
Check that the VP -> PRN connection only occurs if the VP is the head…

### DIFF
--- a/src/edu/stanford/nlp/trees/ModCollinsHeadFinder.java
+++ b/src/edu/stanford/nlp/trees/ModCollinsHeadFinder.java
@@ -131,7 +131,8 @@ public class ModCollinsHeadFinder extends CollinsHeadFinder {
       "ADVP", "TO", "CD", "JJR", "JJ", "IN", "NP", "NML", "JJS", "NN"}});
 
     // SWBD
-    nonTerminalInfo.put("EDITED", new String[][] {{"left"}});  // crap rule for Switchboard (if don't delete EDITED nodes)
+    // crap rule for Switchboard (if don't delete EDITED nodes)
+    nonTerminalInfo.put("EDITED", new String[][]{{"left", "VP", "SQ", "S", "SINV", "SBAR", "NP", "ADJP", "PP", "ADVP", "INTJ", "WHNP", "NAC", "VBP", "JJ", "NN", "NNP"}});
     // in sw2756, a "VB". (copy "VP" to handle this problem, though should really fix it on reading)
     nonTerminalInfo.put("VB", new String[][]{{"left", "TO", "VBD", "VBN", "MD", "VBZ", "VB", "VBG", "VBP", "VP", "AUX", "AUXG", "ADJP", "JJP", "NN", "NNS", "JJ", "NP", "NNP"}});
 

--- a/src/edu/stanford/nlp/trees/UniversalEnglishGrammaticalRelations.java
+++ b/src/edu/stanford/nlp/trees/UniversalEnglishGrammaticalRelations.java
@@ -1385,7 +1385,10 @@ public class UniversalEnglishGrammaticalRelations {
     new GrammaticalRelation(Language.UniversalEnglish, "parataxis", "parataxis",
         DEPENDENT, "S|VP|FRAG|NP", tregexCompiler,
             "VP < (PRN=target < S|SINV|SBAR)", // parenthetical
-            "VP $ (PRN=target [ < S|SINV|SBAR | < VP < @NP ] )", // parenthetical
+            // parenthetical
+            // Testing the head prevents connections between VP and PRN
+            // in situations where VP is not the head of the node containing both
+            "VP ># (__ < (PRN=target [ < S|SINV|SBAR | < VP < @NP ] ))",
             // The next relation handles a colon between sentences
             // and similar punct such as --
             // Sometimes these are lists, especially in the case of ";",


### PR DESCRIPTION
Check that the VP -> PRN connection only occurs if the VP is the head of the shared constituent.  Also, add a slightly less rudimentary EDITED rule to the headfinder.

Resolves the trees mentioned in https://github.com/stanfordnlp/CoreNLP/issues/832

When run on WSJ train, this rule triggered on 522 dependencies before, and now 2 dependencies become `dep` instead.  The connection for the nodes looks more accurate, though.  One possibility is to extend this rule or add a variant which addresses similar nodes with an NP head instead.  Roughly 60 such dependencies occur in WSJ, currently all labeled `dep`, but some of them are questionably `parataxis`.

A stretch goal would be to add rules to convert EDITED to `reparandum`.