### PR TITLE
Fix flaky test in testConnectedComponents

### DIFF
--- a/test/src/edu/stanford/nlp/graph/DirectedMultiGraphTest.java
+++ b/test/src/edu/stanford/nlp/graph/DirectedMultiGraphTest.java
@@ -153,13 +153,16 @@ public class DirectedMultiGraphTest extends TestCase {
   public void testConnectedComponents() {
 
     System.out.println("graph is " + graph.toString());
-    List<Set<Integer>> ccs = graph.getConnectedComponents();
+    Set<Set<Integer>> ccs = new HashSet<>(graph.getConnectedComponents());
     for (Set<Integer> cc : ccs) {
       System.out.println("Connected component: " + cc);
-    }
-    assertEquals(ccs.size(), 4);
-    assertEquals(CollectionUtils.sorted(ccs.get(0)),
-                 Arrays.asList(1, 2, 3, 4));
+    } 
+    Set<Integer> edge1 = new HashSet<>(Arrays.asList(1, 2, 3, 4));
+    Set<Integer> edge2 = new HashSet<>(Arrays.asList(5, 6, 7));
+    Set<Integer> edge3 = new HashSet<>(Arrays.asList(8));
+    Set<Integer> edge4 = new HashSet<>(Arrays.asList(9,10));
+    Set<Set<Integer>> expectedCcs = new HashSet<>(Arrays.asList(edge1,edge2,edge3,edge4));
+    assertEquals(expectedCcs, ccs);
   }
 
   public void testEdgesNodes() {


### PR DESCRIPTION
The original code assumes that `graph.getConnectedComponents()` returns the list of connected components in a particular order. However, this is not the case since `graph.getAllVertices()` relies on  `outgoingEdges.keyset()`, which does not have a definite order. Consequently, `ccs.get(0)` is not guaranteed to contain the elements `(1,2,3,4)`. This issue can cause problems during regression testing because the test case can fail non-deterministically.

My fix essentially removes the concept of order by using Sets. This works since connected components only need to exist in the same collection; it is not necessary for the components to be in any specific order.