### PR TITLE
Replace HashMap with a LinkedHashMap for semgrex.  Makes the order of…

### DIFF
--- a/src/edu/stanford/nlp/semgraph/semgrex/NodeAttributes.java
+++ b/src/edu/stanford/nlp/semgraph/semgrex/NodeAttributes.java
@@ -1,6 +1,6 @@
 package edu.stanford.nlp.semgraph.semgrex;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -23,7 +23,7 @@ public class NodeAttributes {
   public NodeAttributes() {
     root = false;
     empty = false;
-    attributes = new HashMap<>();
+    attributes = new LinkedHashMap<>();
   }
 
   public void setRoot(boolean root) {

--- a/src/edu/stanford/nlp/semgraph/semgrex/NodePattern.java
+++ b/src/edu/stanford/nlp/semgraph/semgrex/NodePattern.java
@@ -3,6 +3,7 @@ package edu.stanford.nlp.semgraph.semgrex;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -10,7 +11,6 @@ import java.util.regex.Pattern;
 
 import edu.stanford.nlp.ling.IndexedWord;
 import edu.stanford.nlp.semgraph.SemanticGraph;
-import edu.stanford.nlp.util.Generics;
 import edu.stanford.nlp.util.Pair;
 import edu.stanford.nlp.util.logging.Redwood;
 
@@ -55,7 +55,9 @@ public class NodePattern extends SemgrexPattern  {
                      List<Pair<Integer, String>> variableGroups) {
     this.reln = r;
     this.negDesc = negDesc;
-    attributes = Generics.newHashMap();
+    // order the attributes so that the pattern stays the same when
+    // printing a compiled pattern
+    attributes = new LinkedHashMap<>();
     descString = "{";
     for (Map.Entry<String, String> entry : attrs.entrySet()) {
       if (!descString.equals("{"))

--- a/test/src/edu/stanford/nlp/semgraph/semgrex/SemgrexTest.java
+++ b/test/src/edu/stanford/nlp/semgraph/semgrex/SemgrexTest.java
@@ -115,6 +115,29 @@ public class SemgrexTest extends TestCase {
             "ate", "ate", "muffins");
   }
 
+  public void testMultipleAttributes() {
+    runTest("{} >> {word:Bill}",
+            "[ate subj>Bill/NNP obj>[muffins compound>blueberry]]",
+            "ate");
+    runTest("{} >> {tag:NNP}",
+            "[ate subj>Bill/NNP obj>[muffins compound>blueberry]]",
+            "ate");
+    runTest("{} >> {word:Bill;tag:NNP}",
+            "[ate subj>Bill/NNP obj>[muffins compound>blueberry]]",
+            "ate");
+    runTest("{} >> {word:Bill;tag:NNZ}",
+            "[ate subj>Bill/NNP obj>[muffins compound>blueberry]]");
+    runTest("{} >> {word:Ragavaniskillinglegacy;tag:NNP}",
+            "[ate subj>Bill/NNP obj>[muffins compound>blueberry]]");
+    runTest("{} >> {tag:NNP;word:Bill}",
+            "[ate subj>Bill/NNP obj>[muffins compound>blueberry]]",
+            "ate");
+    runTest("{} >> {tag:NNZ;word:Bill}",
+            "[ate subj>Bill/NNP obj>[muffins compound>blueberry]]");
+    runTest("{} >> {tag:NNP;word:UnbanMoxOpal}",
+            "[ate subj>Bill/NNP obj>[muffins compound>blueberry]]");
+  }
+
   public void testNamedDependency() {
     runTest("{} << {word:ate}",
             "[ate subj>Bill obj>[muffins compound>blueberry]]",


### PR DESCRIPTION
Replace HashMap with a LinkedHashMap for semgrex.  Makes the order of printing attributes deterministic when printing out a previously parsed semgrex expression

Answers (part of?) #1218