### PR TITLE
Convert SemanticGraph and SemgrexPattern to used LinkedHashMap when p…

### DIFF
--- a/itest/src/edu/stanford/nlp/coref/NeuralChineseCorefBenchmarkSlowITest.java
+++ b/itest/src/edu/stanford/nlp/coref/NeuralChineseCorefBenchmarkSlowITest.java
@@ -9,8 +9,8 @@ public class NeuralChineseCorefBenchmarkSlowITest extends CorefBenchmark {
 
   @Override
   public void setUp() throws Exception, IOException {
-    logger = Redwood.channels(NeuralEnglishCorefCoNLLBenchmarkSlowITest.class);
-    EXPECTED_F1_SCORE = 53.80;
+    logger = Redwood.channels(NeuralChineseCorefBenchmarkSlowITest.class);
+    EXPECTED_F1_SCORE = 54.3;
     PROPERTIES_PATH =  "edu/stanford/nlp/coref/properties/neural-chinese.properties";
     WORK_DIR_NAME = "NeuralChineseCorefBenchmarkTest";
     testName = "Neural Chinese Coref";

--- a/itest/src/edu/stanford/nlp/coref/NeuralEnglishCorefBenchmarkSlowITest.java
+++ b/itest/src/edu/stanford/nlp/coref/NeuralEnglishCorefBenchmarkSlowITest.java
@@ -10,7 +10,7 @@ public class NeuralEnglishCorefBenchmarkSlowITest extends CorefBenchmark {
   @Override
   public void setUp() throws Exception, IOException {
     logger = Redwood.channels(NeuralEnglishCorefCoNLLBenchmarkSlowITest.class);
-    EXPECTED_F1_SCORE = 59.90;
+    EXPECTED_F1_SCORE = 62.15;
     PROPERTIES_PATH =  "edu/stanford/nlp/coref/properties/neural-english.properties";
     WORK_DIR_NAME = "NeuralEnglishCorefBenchmarkTest";
     testName = "Neural English Coref";

--- a/itest/src/edu/stanford/nlp/coref/NeuralEnglishCorefCoNLLBenchmarkSlowITest.java
+++ b/itest/src/edu/stanford/nlp/coref/NeuralEnglishCorefCoNLLBenchmarkSlowITest.java
@@ -9,7 +9,7 @@ public class NeuralEnglishCorefCoNLLBenchmarkSlowITest extends CorefBenchmark {
   @Override
   public void setUp() throws Exception, IOException {
     logger = Redwood.channels(NeuralEnglishCorefCoNLLBenchmarkSlowITest.class);
-    EXPECTED_F1_SCORE = 65.56;
+    EXPECTED_F1_SCORE = 65.51;
     PROPERTIES_PATH =  "edu/stanford/nlp/coref/properties/neural-english-conll.properties";
     WORK_DIR_NAME = "NeuralEnglishCorefCoNLLBenchmarkTest";
     testName = "Neural English Coref (CoNLL)";

--- a/itest/src/edu/stanford/nlp/coref/StatisticalCorefCoNLLBenchmarkSlowITest.java
+++ b/itest/src/edu/stanford/nlp/coref/StatisticalCorefCoNLLBenchmarkSlowITest.java
@@ -10,7 +10,7 @@ public class StatisticalCorefCoNLLBenchmarkSlowITest extends CorefBenchmark {
   @Override
   public void setUp() throws Exception, IOException {
     logger = Redwood.channels(StatisticalCorefCoNLLBenchmarkSlowITest.class);
-    EXPECTED_F1_SCORE = 63.29;
+    EXPECTED_F1_SCORE = 63.27;
     PROPERTIES_PATH =  "edu/stanford/nlp/coref/properties/statistical-english-conll.properties";
     WORK_DIR_NAME = "StatisticalCorefBenchmarkTest";
     testName = "Statistical English Coref (CoNLL)";

--- a/itest/src/edu/stanford/nlp/pipeline/CoreWrapperITest.java
+++ b/itest/src/edu/stanford/nlp/pipeline/CoreWrapperITest.java
@@ -96,7 +96,7 @@ public class CoreWrapperITest {
     assertEquals(expectedDependencyParse, firstSentence.dependencyParse().toString());
     // coref info
     String expectedCoref =
-            "{17=CHAIN17-[\"us\" in sentence 3, \"our\" in sentence 3], 19=CHAIN19-[\"Barack Obama\" in sentence 1, " +
+            "{19=CHAIN19-[\"us\" in sentence 3, \"our\" in sentence 3], 21=CHAIN21-[\"Barack Obama\" in sentence 1, " +
                     "\"He\" in sentence 2, \"Obama\" in sentence 3, \"My\" in sentence 3, \"I\" in sentence 3, \"his\" " +
                     "in sentence 3]}";
     assertEquals(expectedCoref, exampleDocument.corefChains().toString());

--- a/itest/src/edu/stanford/nlp/pipeline/StanfordCoreNLPServerITest.java
+++ b/itest/src/edu/stanford/nlp/pipeline/StanfordCoreNLPServerITest.java
@@ -125,7 +125,7 @@ public class StanfordCoreNLPServerITest {
 
   @Test
   public void testSemgrexJson() throws IOException {
-    String expected="{ \"sentences\": [ { \"0\": { \"text\": \"ate\", \"begin\": 2, \"end\": 3, \"$obj\": { \"text\": \"fish\", \"begin\": 4, \"end\": 5 }, \"$verb\": { \"text\": \"ate\", \"begin\": 2, \"end\": 3 } }, \"length\": 1 }  ]}".replaceAll(" ", "");
+    String expected="{ \"sentences\": [ { \"0\": { \"text\": \"ate\", \"begin\": 2, \"end\": 3, \"$verb\": { \"text\": \"ate\", \"begin\": 2, \"end\": 3 }, \"$obj\": { \"text\": \"fish\", \"begin\": 4, \"end\": 5 } }, \"length\": 1 }  ]}".replaceAll(" ", "");
 
     String query = "The dog ate a fish";
     byte[] message = query.getBytes("utf-8");
@@ -143,7 +143,7 @@ public class StanfordCoreNLPServerITest {
 
   @Test
   public void testSemgrexAnnotation() throws IOException {
-    String expected = "result { result { match { matchIndex: 3 node { name: \"obj\" matchIndex: 5 } node { name: \"verb\" matchIndex: 3 } } }}".replaceAll(" ", "");
+    String expected = "result { result { match { matchIndex: 3 node { name: \"verb\" matchIndex: 3 } node { name: \"obj\" matchIndex: 5 } } }}".replaceAll(" ", "");
     String query = "The dog ate a fish";
     byte[] message = query.getBytes("utf-8");
     Properties props = new Properties();

--- a/itest/src/edu/stanford/nlp/simple/SentenceAlgorithmsITest.java
+++ b/itest/src/edu/stanford/nlp/simple/SentenceAlgorithmsITest.java
@@ -204,8 +204,6 @@ public class SentenceAlgorithmsITest {
       add("Geledi");
       add("<-nmod:of-");
       add("Sultanate");
-      add("<-conj:and-");
-      add("commander");
       add("<-acl:relcl-");
       add("Sultanate");
       add("<-appos-");

--- a/src/edu/stanford/nlp/semgraph/SemanticGraph.java
+++ b/src/edu/stanford/nlp/semgraph/SemanticGraph.java
@@ -71,9 +71,9 @@ public class SemanticGraph implements Serializable  {
 
   private final DirectedMultiGraph<IndexedWord, SemanticGraphEdge> graph;
 
-  private static final MapFactory<IndexedWord, Map<IndexedWord, List<SemanticGraphEdge>>> outerMapFactory = MapFactory.hashMapFactory();
-  private static final MapFactory<IndexedWord, List<SemanticGraphEdge>> innerMapFactory = MapFactory.hashMapFactory();
-  private static final MapFactory<IndexedWord, IndexedWord> wordMapFactory = MapFactory.hashMapFactory();
+  private static final MapFactory<IndexedWord, Map<IndexedWord, List<SemanticGraphEdge>>> outerMapFactory = MapFactory.linkedHashMapFactory();
+  private static final MapFactory<IndexedWord, List<SemanticGraphEdge>> innerMapFactory = MapFactory.linkedHashMapFactory();
+  private static final MapFactory<IndexedWord, IndexedWord> wordMapFactory = MapFactory.linkedHashMapFactory();
 
   private LinkedList<String> comments = new LinkedList<>();
 

--- a/src/edu/stanford/nlp/semgraph/semgrex/SemgrexPattern.java
+++ b/src/edu/stanford/nlp/semgraph/semgrex/SemgrexPattern.java
@@ -249,8 +249,7 @@ public abstract class SemgrexPattern implements Serializable  {
    * @return a SemgrexMatcher
    */
   public SemgrexMatcher matcher(SemanticGraph sg) {
-    return matcher(sg, sg.getFirstRoot(), Generics.newHashMap(), Generics.newHashMap(),
-        new VariableStrings(), false);
+    return matcher(sg, sg.getFirstRoot(), new LinkedHashMap<>(), new LinkedHashMap<>(), new VariableStrings(), false);
   }
 
   /**
@@ -261,8 +260,7 @@ public abstract class SemgrexPattern implements Serializable  {
    * @return a SemgrexMatcher
    */
   public SemgrexMatcher matcher(SemanticGraph sg, IndexedWord root) {
-    return matcher(sg, root, Generics.<String, IndexedWord>newHashMap(), Generics.<String, String>newHashMap(),
-        new VariableStrings(), false);
+    return matcher(sg, root, new LinkedHashMap<>(), new LinkedHashMap<>(), new VariableStrings(), false);
   }
 
   /**
@@ -270,7 +268,7 @@ public abstract class SemgrexPattern implements Serializable  {
    * initial conditions on the variable assignments
    */
   public SemgrexMatcher matcher(SemanticGraph sg, Map<String, IndexedWord> variables) {
-    return matcher(sg, sg.getFirstRoot(), variables, Generics.newHashMap(), new VariableStrings(), false);
+    return matcher(sg, sg.getFirstRoot(), variables, new LinkedHashMap<>(), new VariableStrings(), false);
   }
 
   /**
@@ -282,18 +280,15 @@ public abstract class SemgrexPattern implements Serializable  {
    * @return a SemgrexMatcher
    */
   public SemgrexMatcher matcher(SemanticGraph sg, boolean ignoreCase) {
-    return matcher(sg, sg.getFirstRoot(), Generics.newHashMap(), Generics.newHashMap(),
-        new VariableStrings(), ignoreCase);
+    return matcher(sg, sg.getFirstRoot(), new LinkedHashMap<>(), new LinkedHashMap<>(), new VariableStrings(), ignoreCase);
   }
 
   public SemgrexMatcher matcher(SemanticGraph hypGraph, Alignment alignment, SemanticGraph txtGraph) {
-    return matcher(hypGraph, alignment, txtGraph, true, hypGraph.getFirstRoot(), Generics.newHashMap(),
-        Generics.newHashMap(), new VariableStrings(), false);
+    return matcher(hypGraph, alignment, txtGraph, true, hypGraph.getFirstRoot(), new LinkedHashMap<>(), new LinkedHashMap<>(), new VariableStrings(), false);
   }
 
   public SemgrexMatcher matcher(SemanticGraph hypGraph, Alignment alignment, SemanticGraph txtGraph, boolean ignoreCase) {
-    return matcher(hypGraph, alignment, txtGraph, true, hypGraph.getFirstRoot(), Generics.newHashMap(),
-        Generics.newHashMap(), new VariableStrings(), ignoreCase);
+    return matcher(hypGraph, alignment, txtGraph, true, hypGraph.getFirstRoot(), new LinkedHashMap<>(), new LinkedHashMap<>(), new VariableStrings(), ignoreCase);
   }
 
   // compile method

--- a/test/src/edu/stanford/nlp/trees/UniversalEnglishGrammaticalStructureTest.java
+++ b/test/src/edu/stanford/nlp/trees/UniversalEnglishGrammaticalStructureTest.java
@@ -2285,12 +2285,12 @@ public class UniversalEnglishGrammaticalStructureTest extends Assert {
                "nmod:in(failures-7, politics-9)\n" +
                "case(economy-13, in-11)\n" +
                "det(economy-13, the-12)\n" +
-               "nmod:in(failures-7'', economy-13)\n" +
-               "cc(failures-7', or-14)\n" +
+               "nmod:in(failures-7', economy-13)\n" +
+               "cc(failures-7'', or-14)\n" +
                "case(front-18, on-15)\n" +
                "det(front-18, the-16)\n" +
                "amod(front-18, military-17)\n" +
-               "nmod:on(failures-7', front-18)\n" +
+               "nmod:on(failures-7'', front-18)\n" +
                "cc(chalked-22, and-20)\n" +
                "aux(chalked-22, has-21)\n" +
                "conj:and(produced-4, chalked-22)\n" +
@@ -2382,18 +2382,18 @@ public class UniversalEnglishGrammaticalStructureTest extends Assert {
                "obl:out(walked-2, door-5)\n" +
                "case(road-9, over-7)\n" +
                "det(road-9, the-8)\n" +
-               "obl:over(walked-2''', road-9)\n" +
+               "obl:over(walked-2', road-9)\n" +
                "case(block-14, across-11)\n" +
                "det(block-14, the-12)\n" +
                "amod(block-14, deserted-13)\n" +
-               "obl:across(walked-2'''', block-14)\n" +
+               "obl:across(walked-2'', block-14)\n" +
                "case(corner-18, around-16)\n" +
                "det(corner-18, the-17)\n" +
-               "obl:around(walked-2', corner-18)\n" +
-               "cc(walked-2'', and-20)\n" +
+               "obl:around(walked-2''', corner-18)\n" +
+               "cc(walked-2'''', and-20)\n" +
                "case(park-23, through-21)\n" +
                "det(park-23, the-22)\n" +
-               "obl:through(walked-2'', park-23)\n"},
+               "obl:through(walked-2'''', park-23)\n"},
              {TestType.CC_PROCESSED,
               "(ROOT (S (NP (NNP John)) (VP (VP (VBD noticed) (NP (DT a) (NN cockroach))) (CC and) (VP (VBD departed))) (. .)))",
               "nsubj(noticed-2, John-1)\n" +


### PR DESCRIPTION
Convert SemanticGraph and SemgrexPattern to used LinkedHashMap when possible.  Ensures a consistent order when adding and removing new nodes.  Update a test to reflect the changed order.