### PR TITLE
Fix negated disjunction - there is an infinite loop if the first clau…

### DIFF
--- a/src/edu/stanford/nlp/trees/tregex/CoordinationPattern.java
+++ b/src/edu/stanford/nlp/trees/tregex/CoordinationPattern.java
@@ -155,8 +155,8 @@ class CoordinationPattern extends TregexPattern {
               }
               return true;
             }
-          } else {
-            // oops, this didn't work.
+          } else if (!myNode.isNegated()) {
+            // oops, this didn't work - positive conjunction version
             children[currChild].resetChildIter();
             // go backwards to see if we can continue matching from an
             // earlier location.
@@ -164,6 +164,16 @@ class CoordinationPattern extends TregexPattern {
             if (currChild < 0) {
               return myNode.isOptional();
             }
+          } else {
+            // oops, this didn't work - negated disjunction version
+            // here we just fail
+            // any previous children had to fail to get to this point,
+            // which means those children have only the one correct state.
+            // backtracking to find other correct states is pointless
+            // and in fact causes an infinite loop of going backwards,
+            // then advancing back to this child and failing again
+            currChild = -1;
+            return myNode.isOptional();
           }
         }
       } else {

--- a/test/src/edu/stanford/nlp/trees/tregex/TregexTest.java
+++ b/test/src/edu/stanford/nlp/trees/tregex/TregexTest.java
@@ -1457,6 +1457,22 @@ public class TregexTest extends TestCase {
   }
 
   /**
+   * A user supplied an example of a negated disjunction which went into an infinite loop.
+   * Apparently no one had ever used a negated disjunction of tree structures before!
+   * <br>
+   * The problem was that the logic at the time tried to backtrack in
+   * the disjunction to find a better match, but that resulted in it
+   * going back and forth between the failed clause which was accepted
+   * and the successful clause which was rejected.  The problem being
+   * that the first half of the disjunction doesn't match, so the
+   * pattern is successful up to that point, but the second half does
+   * match, causing the pattern to be rejected and restarted.
+   */
+  public void testNegatedDisjunction() {
+    runTest("NP![</,/|.(JJ<else)]", "( (NP (NP (NN anyone)) (ADJP (JJ else))))", "(NP (NP (NN anyone)) (ADJP (JJ else)))");
+  }
+
+  /**
    * Stores an input and the expected output.  Obviously this is only
    * expected to work with a given pattern, but this is a bit more
    * convenient than calling the same pattern by hand over and over


### PR DESCRIPTION
Fix negated disjunction - there is an infinite loop if the first clause(s) of the negated disjunction fail and one of the later clauses passes