### PR TITLE
Linked properties

### DIFF
--- a/src/edu/stanford/nlp/process/PTBLexer.flex
+++ b/src/edu/stanford/nlp/process/PTBLexer.flex
@@ -28,9 +28,9 @@ package edu.stanford.nlp.process;
 
 import java.io.Reader;
 import java.text.Normalizer;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -139,11 +139,11 @@ import edu.stanford.nlp.util.logging.Redwood;
         if (options == null) {
           options = "";
         }
-        Properties prop = StringUtils.stringToProperties(options);
-        Set<Map.Entry<Object,Object>> props = prop.entrySet();
-        for (Map.Entry<Object,Object> item : props) {
-          String key = (String) item.getKey();
-          String value = (String) item.getValue();
+        LinkedHashMap<String, String> prop = StringUtils.stringToPropertiesMap(options);
+        Set<Map.Entry<String, String>> props = prop.entrySet();
+        for (Map.Entry<String, String> item : props) {
+          String key = item.getKey();
+          String value = item.getValue();
           boolean val = Boolean.parseBoolean(value);
           if ("".equals(key)) {
             // allow an empty item

--- a/src/edu/stanford/nlp/process/PTBLexer.java
+++ b/src/edu/stanford/nlp/process/PTBLexer.java
@@ -32,9 +32,9 @@ package edu.stanford.nlp.process;
 
 import java.io.Reader;
 import java.text.Normalizer;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -60954,11 +60954,11 @@ class PTBLexer {
         if (options == null) {
           options = "";
         }
-        Properties prop = StringUtils.stringToProperties(options);
-        Set<Map.Entry<Object,Object>> props = prop.entrySet();
-        for (Map.Entry<Object,Object> item : props) {
-          String key = (String) item.getKey();
-          String value = (String) item.getValue();
+        LinkedHashMap<String, String> prop = StringUtils.stringToPropertiesMap(options);
+        Set<Map.Entry<String, String>> props = prop.entrySet();
+        for (Map.Entry<String, String> item : props) {
+          String key = item.getKey();
+          String value = item.getValue();
           boolean val = Boolean.parseBoolean(value);
           if ("".equals(key)) {
             // allow an empty item

--- a/src/edu/stanford/nlp/process/WhitespaceTokenizer.java
+++ b/src/edu/stanford/nlp/process/WhitespaceTokenizer.java
@@ -7,12 +7,12 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.util.Iterator;
-import java.util.Properties;
+import java.util.LinkedHashMap;
 
 import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.ling.HasWord;
 import edu.stanford.nlp.ling.Word;
-import edu.stanford.nlp.util.PropertiesUtils;
+import edu.stanford.nlp.util.Maps;
 import edu.stanford.nlp.util.StringUtils;
 
 /**
@@ -76,8 +76,8 @@ public class WhitespaceTokenizer<T extends HasWord> extends AbstractTokenizer<T>
     public WhitespaceTokenizerFactory(LexedTokenFactory<T> factory,
                                       String options) {
       this.factory = factory;
-      Properties prop = StringUtils.stringToProperties(options);
-      this.tokenizeNLs = PropertiesUtils.getBool(prop, "tokenizeNLs", false);
+      LinkedHashMap<String, String> prop = StringUtils.stringToPropertiesMap(options);
+      this.tokenizeNLs = Maps.getBool(prop, "tokenizeNLs", false);
     }
 
     public WhitespaceTokenizerFactory(LexedTokenFactory<T> factory,
@@ -98,16 +98,16 @@ public class WhitespaceTokenizer<T extends HasWord> extends AbstractTokenizer<T>
 
     @Override
     public Tokenizer<T> getTokenizer(Reader r, String extraOptions) {
-      Properties prop = StringUtils.stringToProperties(extraOptions);
-      boolean tokenizeNewlines = PropertiesUtils.getBool(prop, "tokenizeNLs", this.tokenizeNLs);
+      LinkedHashMap<String, String> prop = StringUtils.stringToPropertiesMap(extraOptions);
+      boolean tokenizeNewlines = Maps.getBool(prop, "tokenizeNLs", this.tokenizeNLs);
 
       return new WhitespaceTokenizer<>(factory, r, tokenizeNewlines);
     }
 
     @Override
     public void setOptions(String options) {
-      Properties prop = StringUtils.stringToProperties(options);
-      tokenizeNLs = PropertiesUtils.getBool(prop, "tokenizeNLs", tokenizeNLs);
+      LinkedHashMap<String, String> prop = StringUtils.stringToPropertiesMap(options);
+      tokenizeNLs = Maps.getBool(prop, "tokenizeNLs", tokenizeNLs);
     }
 
   } // end class WhitespaceTokenizerFactory

--- a/src/edu/stanford/nlp/process/WordSegmentingTokenizer.java
+++ b/src/edu/stanford/nlp/process/WordSegmentingTokenizer.java
@@ -5,11 +5,11 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Properties;
+import java.util.LinkedHashMap;
 
 import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.ling.HasWord;
-import edu.stanford.nlp.util.PropertiesUtils;
+import edu.stanford.nlp.util.Maps;
 import edu.stanford.nlp.util.StringUtils;
 
 /** A tokenizer that works by calling a WordSegmenter.
@@ -82,16 +82,16 @@ public class WordSegmentingTokenizer extends AbstractTokenizer<HasWord> {
     public Tokenizer<HasWord> getTokenizer(Reader r, String extraOptions) {
       boolean tokenizeNewlines = this.tokenizeNLs;
       if (extraOptions != null) {
-        Properties prop = StringUtils.stringToProperties(extraOptions);
-        tokenizeNewlines = PropertiesUtils.getBool(prop, "tokenizeNLs", this.tokenizeNLs);
+        LinkedHashMap<String, String> prop = StringUtils.stringToPropertiesMap(extraOptions);
+        tokenizeNewlines = Maps.getBool(prop, "tokenizeNLs", this.tokenizeNLs);
       }
 
       return new WordSegmentingTokenizer(segmenter, WhitespaceTokenizer.newCoreLabelWhitespaceTokenizer(r, tokenizeNewlines));
     }
 
     public void setOptions(String options) {
-      Properties prop = StringUtils.stringToProperties(options);
-      tokenizeNLs = PropertiesUtils.getBool(prop, "tokenizeNLs", tokenizeNLs);
+      LinkedHashMap<String, String> prop = StringUtils.stringToPropertiesMap(options);
+      tokenizeNLs = Maps.getBool(prop, "tokenizeNLs", tokenizeNLs);
     }
   }
 }

--- a/src/edu/stanford/nlp/trees/TreePrint.java
+++ b/src/edu/stanford/nlp/trees/TreePrint.java
@@ -51,8 +51,8 @@ public class TreePrint  {
     "conll2007"
   };
 
-  private final Properties formats;
-  private final Properties options;
+  private final LinkedHashMap<String, String> formats;
+  private final LinkedHashMap<String, String> options;
 
   private final boolean markHeadNodes; // = false;
   private final boolean lexicalize; // = false;
@@ -143,11 +143,10 @@ public class TreePrint  {
    * @param hf      The HeadFinder used in printing output
    */
   public TreePrint(String formatString, String optionsString, TreebankLanguagePack tlp, HeadFinder hf, HeadFinder typedDependencyHF) {
-    formats = StringUtils.stringToProperties(formatString);
-    options = StringUtils.stringToProperties(optionsString);
+    formats = StringUtils.stringToPropertiesMap(formatString);
+    options = StringUtils.stringToPropertiesMap(optionsString);
     List<String> okOutputs = Arrays.asList(outputTreeFormats);
-    for (Object formObj : formats.keySet()) {
-      String format = (String) formObj;
+    for (String format : formats.keySet()) {
       if ( ! okOutputs.contains(format)) {
         throw new RuntimeException("Error: output tree format " + format + " not supported. Known formats are: " + okOutputs);
       }
@@ -208,8 +207,8 @@ public class TreePrint  {
   }
 
 
-  private static boolean propertyToBoolean(Properties prop, String key) {
-    return Boolean.parseBoolean(prop.getProperty(key));
+  private static boolean propertyToBoolean(LinkedHashMap<String, String> prop, String key) {
+    return Boolean.parseBoolean(prop.get(key));
   }
 
   /**

--- a/src/edu/stanford/nlp/util/Maps.java
+++ b/src/edu/stanford/nlp/util/Maps.java
@@ -165,6 +165,26 @@ public class Maps {
   }
 
   /**
+   * Load a boolean property from a Map.  If the key is not present, returns false.
+   */
+  public static boolean getBool(Map<String, String> props, String key) {
+    return getBool(props, key, false);
+  }
+
+  /**
+   * Load a boolean property from a Map.  If the key is not present, returns defaultValue.
+   */
+  public static boolean getBool(Map<String, String> props, String key,
+                                boolean defaultValue) {
+    String value = props.get(key);
+    if (value != null) {
+      return Boolean.parseBoolean(value);
+    } else {
+      return defaultValue;
+    }
+  }
+
+  /**
    * Pretty print a Counter. This one has more flexibility in formatting, and
    * doesn't sort the keys.
    */

--- a/src/edu/stanford/nlp/util/StringUtils.java
+++ b/src/edu/stanford/nlp/util/StringUtils.java
@@ -1137,6 +1137,35 @@ public class StringUtils  {
   }
 
   /**
+   * This method updates a LinkedHashMap based on
+   * a comma-separated String (with whitespace
+   * optionally allowed after the comma) representing properties
+   * to a Properties object.  Each property is "property=value".  The value
+   * for properties without an explicitly given value is set to "true".
+   *
+   * TODO: remove the stringToProperties version
+   */
+  public static LinkedHashMap<String, String> stringToPropertiesMap(String str) {
+    LinkedHashMap<String, String> props = new LinkedHashMap<>();
+
+    String[] propsStr = str.trim().split(",\\s*");
+    for (String term : propsStr) {
+      int divLoc = term.indexOf('=');
+      String key;
+      String value;
+      if (divLoc >= 0) {
+        key = term.substring(0, divLoc).trim();
+        value = term.substring(divLoc + 1).trim();
+      } else {
+        key = term.trim();
+        value = "true";
+      }
+      props.put(key, value);
+    }
+    return props;
+  }
+
+  /**
    * If any of the given list of properties are not found, returns the
    * name of that property.  Otherwise, returns null.
    */


### PR DESCRIPTION
Turn a bunch of `Properties` into `LinkedHashMap` to prevent weird issues arising when properties are iterated in different orders