### PR TITLE
fix(sec): upgrade com.google.protobuf:protobuf-java to 3.21.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.19.2</version>
+      <version>3.21.7</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.protobuf:protobuf-java 3.19.2
- [CVE-2022-3171](https://www.oscs1024.com/hd/CVE-2022-3171)


### What did I do？
Upgrade com.google.protobuf:protobuf-java from 3.19.2 to 3.21.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS