### PR TITLE
Add a guide to install by Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ The jars can be directly downloaded from the links below or the Hugging Face Hub
 
 Thank you to [Hugging Face](https://huggingface.co/) for helping with our hosting!
 
+### Install by Gradle
+
+If you don't know Gradle itself, see official site: https://gradle.org
+
+Write the following in your build.gradle according to [Maven Central](https://search.maven.org/artifact/edu.stanford.nlp/stanford-corenlp/4.5.1/jar):
+
+```Gradle
+dependencies {
+    implementation 'edu.stanford.nlp:stanford-corenlp:4.5.1'
+}
+```
+
+If you want to analyse English, add following:
+
+```Gradle
+    implementation "edu.stanford.nlp:stanford-corenlp:4.5.1:models"
+    implementation "edu.stanford.nlp:stanford-corenlp:4.5.1:models-english"
+    implementation "edu.stanford.nlp:stanford-corenlp:4.5.1:models-english-kbp"
+```
+
 ### Useful resources
 
 You can find releases of Stanford CoreNLP on [Maven Central](https://search.maven.org/artifact/edu.stanford.nlp/stanford-corenlp/4.5.1/jar).

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ If you want to analyse English, add following:
     implementation "edu.stanford.nlp:stanford-corenlp:4.5.1:models-english-kbp"
 ```
 
+If you use other version, replace "4.5.1" to a version you use.
+
 ### Useful resources
 
 You can find releases of Stanford CoreNLP on [Maven Central](https://search.maven.org/artifact/edu.stanford.nlp/stanford-corenlp/4.5.1/jar).


### PR DESCRIPTION
I wrote a guide to install by Gradle.

However, I don't know a way for other languages models because I don't know the names.  This Gradle code works because you deployed them, so I think you know the names.

By the way, I use your library to develop the following Twitter Trend Analysis bot:
https://twitter.com/Trend_words_en_