### PR TITLE
Collinizer

### DIFF
--- a/src/edu/stanford/nlp/parser/lexparser/AbstractCollinizer.java
+++ b/src/edu/stanford/nlp/parser/lexparser/AbstractCollinizer.java
@@ -1,0 +1,6 @@
+package edu.stanford.nlp.parser.lexparser;
+
+import edu.stanford.nlp.trees.TreeTransformer;
+
+public abstract class AbstractCollinizer implements TreeTransformer {
+}

--- a/src/edu/stanford/nlp/parser/lexparser/AbstractCollinizer.java
+++ b/src/edu/stanford/nlp/parser/lexparser/AbstractCollinizer.java
@@ -10,5 +10,5 @@ import edu.stanford.nlp.trees.Tree;
  * @author John Bauer
  */
 public interface AbstractCollinizer  {
-  Tree transformTree(Tree guess);
+  Tree transformTree(Tree guess, Tree gold);
 }

--- a/src/edu/stanford/nlp/parser/lexparser/AbstractCollinizer.java
+++ b/src/edu/stanford/nlp/parser/lexparser/AbstractCollinizer.java
@@ -1,6 +1,14 @@
 package edu.stanford.nlp.parser.lexparser;
 
-import edu.stanford.nlp.trees.TreeTransformer;
+import edu.stanford.nlp.trees.Tree;
 
-public abstract class AbstractCollinizer implements TreeTransformer {
+/**
+ * Interface for the Collinizers
+ *<br>
+ * TODO: pass in both the guess and the gold
+ *
+ * @author John Bauer
+ */
+public interface AbstractCollinizer  {
+  Tree transformTree(Tree guess);
 }

--- a/src/edu/stanford/nlp/parser/lexparser/AbstractTreebankParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/AbstractTreebankParserParams.java
@@ -336,7 +336,7 @@ public abstract class AbstractTreebankParserParams implements TreebankLangParser
    * tree. Should strip punctuation and maybe do some other things.
    */
   @Override
-  public abstract TreeTransformer collinizer();
+  public abstract AbstractCollinizer collinizer();
 
   /**
    * the tree transformer used to produce trees for evaluation.  Will
@@ -346,7 +346,7 @@ public abstract class AbstractTreebankParserParams implements TreebankLangParser
    * off. (finish this doc!)
    */
   @Override
-  public abstract TreeTransformer collinizerEvalb();
+  public abstract AbstractCollinizer collinizerEvalb();
 
 
   /**

--- a/src/edu/stanford/nlp/parser/lexparser/ArabicTreebankParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/ArabicTreebankParserParams.java
@@ -207,7 +207,7 @@ public class ArabicTreebankParserParams extends AbstractTreebankParserParams  {
    * The collinizer eliminates punctuation
    */
   @Override
-  public TreeTransformer collinizer() {
+  public AbstractCollinizer collinizer() {
     return new TreeCollinizer(tlp, !collinizerRetainsPunctuation, false);
   }
 
@@ -215,7 +215,7 @@ public class ArabicTreebankParserParams extends AbstractTreebankParserParams  {
    * Stand-in collinizer does nothing to the tree.
    */
   @Override
-  public TreeTransformer collinizerEvalb() {
+  public AbstractCollinizer collinizerEvalb() {
     return collinizer();
   }
 

--- a/src/edu/stanford/nlp/parser/lexparser/ChineseCharacterBasedLexiconTraining.java
+++ b/src/edu/stanford/nlp/parser/lexparser/ChineseCharacterBasedLexiconTraining.java
@@ -282,7 +282,7 @@ public class ChineseCharacterBasedLexiconTraining  {
       FileFilter testFilt = new NumberRangesFileFilter(testArgs[1], false);
       testTreebank.loadPath(new File(testArgs[0]), testFilt);
       TreeTransformer subcategoryStripper = op.tlpParams.subcategoryStripper();
-      TreeTransformer collinizer = ctpp.collinizer();
+      AbstractCollinizer collinizer = ctpp.collinizer();
 
       WordCatEquivalenceClasser eqclass = new WordCatEquivalenceClasser();
       WordCatEqualityChecker eqcheck = new WordCatEqualityChecker();

--- a/src/edu/stanford/nlp/parser/lexparser/ChineseCharacterBasedLexiconTraining.java
+++ b/src/edu/stanford/nlp/parser/lexparser/ChineseCharacterBasedLexiconTraining.java
@@ -371,8 +371,8 @@ public class ChineseCharacterBasedLexiconTraining  {
           System.out.println("\nScores:");
           basicEval.displayLast();
 
-          Tree collinsTree = collinizer.transformTree(tree);
-          Tree collinsGold = collinizer.transformTree(gold);
+          Tree collinsTree = collinizer.transformTree(tree, gold);
+          Tree collinsGold = collinizer.transformTree(gold, gold);
           ourBrackets = proc.allBrackets(collinsTree);
           goldBrackets = proc.allBrackets(collinsGold);
           if (goodPOS) {

--- a/src/edu/stanford/nlp/parser/lexparser/ChineseTreebankParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/ChineseTreebankParserParams.java
@@ -178,7 +178,7 @@ public class ChineseTreebankParserParams extends AbstractTreebankParserParams  {
    * Returns a ChineseCollinizer
    */
   @Override
-  public TreeTransformer collinizer() {
+  public AbstractCollinizer collinizer() {
     return new ChineseCollinizer(ctlp);
   }
 
@@ -186,7 +186,7 @@ public class ChineseTreebankParserParams extends AbstractTreebankParserParams  {
    * Returns a ChineseCollinizer that doesn't delete punctuation
    */
   @Override
-  public TreeTransformer collinizerEvalb() {
+  public AbstractCollinizer collinizerEvalb() {
     return new ChineseCollinizer(ctlp, false);
   }
 

--- a/src/edu/stanford/nlp/parser/lexparser/EnglishTreebankParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/EnglishTreebankParserParams.java
@@ -221,12 +221,12 @@ public class EnglishTreebankParserParams extends AbstractTreebankParserParams  {
    * be applied both to the parser output and the gold tree.
    */
   @Override
-  public TreeTransformer collinizer() {
+  public AbstractCollinizer collinizer() {
     return new TreeCollinizer(tlp, true, englishTrain.splitBaseNP == 2, englishTrain.collapseWhCategories);
   }
 
   @Override
-  public TreeTransformer collinizerEvalb() {
+  public AbstractCollinizer collinizerEvalb() {
     return new TreeCollinizer(tlp, true, englishTrain.splitBaseNP == 2, englishTrain.collapseWhCategories);
   }
 

--- a/src/edu/stanford/nlp/parser/lexparser/FactoredParser.java
+++ b/src/edu/stanford/nlp/parser/lexparser/FactoredParser.java
@@ -471,8 +471,8 @@ public class FactoredParser  {
         //System.out.println("True Best Parse:");
         //tree.pennPrint();
         //tc.transformTree(tree).pennPrint();
-        pcfgPE.evaluate(tc.transformTree(tree2), tc.transformTree(tree), pw);
-        pcfgCB.evaluate(tc.transformTree(tree2), tc.transformTree(tree), pw);
+        pcfgPE.evaluate(tc.transformTree(tree2, tree2), tc.transformTree(tree, tree), pw);
+        pcfgCB.evaluate(tc.transformTree(tree2, tree2), tc.transformTree(tree, tree), pw);
         Tree tree4b = null;
         if (op.doDep) {
           comboDE.evaluate((bothPassed ? tree4 : tree3), binaryTree, pw);
@@ -483,15 +483,15 @@ public class FactoredParser  {
             tree4 = np.prune(tree4);
           }
           //tree4.pennPrint();
-          comboPE.evaluate(tc.transformTree(tree4), tc.transformTree(tree), pw);
+          comboPE.evaluate(tc.transformTree(tree4, tree4), tc.transformTree(tree, tree), pw);
         }
         //pcfgTE.evaluate(tree2, tree);
-        pcfgTE.evaluate(tcEvalb.transformTree(tree2), tcEvalb.transformTree(tree), pw);
-        pcfgTEnoPunct.evaluate(tc.transformTree(tree2), tc.transformTree(tree), pw);
+        pcfgTE.evaluate(tcEvalb.transformTree(tree2, tree2), tcEvalb.transformTree(tree, tree), pw);
+        pcfgTEnoPunct.evaluate(tc.transformTree(tree2, tree2), tc.transformTree(tree, tree), pw);
 
         if (op.doDep) {
-          comboTE.evaluate(tcEvalb.transformTree(tree4), tcEvalb.transformTree(tree), pw);
-          comboTEnoPunct.evaluate(tc.transformTree(tree4), tc.transformTree(tree), pw);
+          comboTE.evaluate(tcEvalb.transformTree(tree4, tree4), tcEvalb.transformTree(tree, tree), pw);
+          comboTEnoPunct.evaluate(tc.transformTree(tree4, tree4), tc.transformTree(tree, tree), pw);
         }
         System.out.println("PCFG only: " + parser.scoreBinarizedTree(tree2b, 0));
 
@@ -515,11 +515,11 @@ public class FactoredParser  {
 
       if (op.testOptions.evalb) {
         if (op.doPCFG && op.doDep) {
-          EvalbFormatWriter.writeEVALBline(tcEvalb.transformTree(tree), tcEvalb.transformTree(tree4));
+          EvalbFormatWriter.writeEVALBline(tcEvalb.transformTree(tree, tree), tcEvalb.transformTree(tree4, tree4));
         } else if (op.doPCFG) {
-          EvalbFormatWriter.writeEVALBline(tcEvalb.transformTree(tree), tcEvalb.transformTree(tree2));
+          EvalbFormatWriter.writeEVALBline(tcEvalb.transformTree(tree, tree), tcEvalb.transformTree(tree2, tree2));
         } else if (op.doDep) {
-          EvalbFormatWriter.writeEVALBline(tcEvalb.transformTree(tree), tcEvalb.transformTree(tree3db));
+          EvalbFormatWriter.writeEVALBline(tcEvalb.transformTree(tree, tree), tcEvalb.transformTree(tree3db, tree3db));
         }
       }
     } // end for each tree in test treebank

--- a/src/edu/stanford/nlp/parser/lexparser/FactoredParser.java
+++ b/src/edu/stanford/nlp/parser/lexparser/FactoredParser.java
@@ -461,8 +461,8 @@ public class FactoredParser  {
         depDE.evaluate(tree3, binaryTree, pw);
         depTE.evaluate(tree3db, tree, pw);
       }
-      TreeTransformer tc = op.tlpParams.collinizer();
-      TreeTransformer tcEvalb = op.tlpParams.collinizerEvalb();
+      AbstractCollinizer tc = op.tlpParams.collinizer();
+      AbstractCollinizer tcEvalb = op.tlpParams.collinizerEvalb();
       if (op.doPCFG) {
         // System.out.println("XXXX Best PCFG was: ");
         // tree2.pennPrint();

--- a/src/edu/stanford/nlp/parser/lexparser/FrenchTreebankParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/FrenchTreebankParserParams.java
@@ -549,12 +549,12 @@ public class FrenchTreebankParserParams extends TregexPoweredTreebankParserParam
   }
 
   @Override
-  public TreeTransformer collinizer() {
+  public AbstractCollinizer collinizer() {
     return new TreeCollinizer(treebankLanguagePack());
   }
 
   @Override
-  public TreeTransformer collinizerEvalb() {
+  public AbstractCollinizer collinizerEvalb() {
     return new TreeCollinizer(treebankLanguagePack(),collinizerRetainsPunctuation,false);
   }
 

--- a/src/edu/stanford/nlp/parser/lexparser/GenericTreebankParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/GenericTreebankParserParams.java
@@ -24,13 +24,13 @@ public class GenericTreebankParserParams extends AbstractTreebankParserParams {
   }
 
   @Override
-  public TreeTransformer collinizer() {
+  public AbstractCollinizer collinizer() {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public TreeTransformer collinizerEvalb() {
+  public AbstractCollinizer collinizerEvalb() {
     // TODO Auto-generated method stub
     return null;
   }

--- a/src/edu/stanford/nlp/parser/lexparser/HebrewTreebankParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/HebrewTreebankParserParams.java
@@ -47,7 +47,7 @@ public class HebrewTreebankParserParams extends AbstractTreebankParserParams  {
   }
 
   @Override
-  public TreeTransformer collinizer() {
+  public AbstractCollinizer collinizer() {
     return new TreeCollinizer(tlp, true, false);
   }
 
@@ -55,7 +55,7 @@ public class HebrewTreebankParserParams extends AbstractTreebankParserParams  {
    * Stand-in collinizer does nothing to the tree.
    */
   @Override
-  public TreeTransformer collinizerEvalb() {
+  public AbstractCollinizer collinizerEvalb() {
     return collinizer();
   }
 

--- a/src/edu/stanford/nlp/parser/lexparser/HungarianTreebankParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/HungarianTreebankParserParams.java
@@ -53,12 +53,12 @@ public class HungarianTreebankParserParams extends AbstractTreebankParserParams 
   }
 
   @Override
-  public TreeTransformer collinizer() {
+  public AbstractCollinizer collinizer() {
     return new TreeCollinizer(tlp, true, false, 0);
   }
 
   @Override
-  public TreeTransformer collinizerEvalb() {
+  public AbstractCollinizer collinizerEvalb() {
     return collinizer();
   }
 

--- a/src/edu/stanford/nlp/parser/lexparser/ItalianTreebankParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/ItalianTreebankParserParams.java
@@ -53,12 +53,12 @@ public class ItalianTreebankParserParams extends AbstractTreebankParserParams  {
   }
 
   @Override
-  public TreeTransformer collinizer() {
+  public AbstractCollinizer collinizer() {
     return new TreeCollinizer(tlp, true, false, 0);
   }
 
   @Override
-  public TreeTransformer collinizerEvalb() {
+  public AbstractCollinizer collinizerEvalb() {
     return collinizer();
   }
 

--- a/src/edu/stanford/nlp/parser/lexparser/NegraPennCollinizer.java
+++ b/src/edu/stanford/nlp/parser/lexparser/NegraPennCollinizer.java
@@ -12,7 +12,7 @@ import edu.stanford.nlp.trees.TreeFactory;
 import edu.stanford.nlp.trees.TreeTransformer;
 
 
-public class NegraPennCollinizer extends AbstractCollinizer {
+public class NegraPennCollinizer implements AbstractCollinizer {
 
   /** A logger for this class */
   Redwood.RedwoodChannels log = Redwood.channels(NegraPennCollinizer.class);

--- a/src/edu/stanford/nlp/parser/lexparser/NegraPennCollinizer.java
+++ b/src/edu/stanford/nlp/parser/lexparser/NegraPennCollinizer.java
@@ -48,12 +48,13 @@ public class NegraPennCollinizer implements AbstractCollinizer {
     }
     String s = l.value();
     s = tlpp.treebankLanguagePack().basicCategory(s);
-    if (deletePunct) {
-      // this is broken as it's not the right thing to do when there
-      // is any tag ambiguity -- and there is for ' (POS/'').  Sentences
-      // can then have more or less words.  It's also unnecessary for EVALB,
-      // since it ignores punctuation anyway
-      if (guess.isPreTerminal() && tlpp.treebankLanguagePack().isEvalBIgnoredPunctuationTag(s)) {
+    if (deletePunct && guess.isPreTerminal()) {
+      // Eliminate unwanted (in terms of evaluation) punctuation
+      // by comparing the gold punctuation, not the guess tree
+      // This way, retagging does not change the results
+      Tree goldPT = goldPreterminals.next();
+      String goldTag = tlpp.treebankLanguagePack().basicCategory(goldPT.value());
+      if (tlpp.treebankLanguagePack().isEvalBIgnoredPunctuationTag(goldTag)) {
         return null;
       }
     }

--- a/src/edu/stanford/nlp/parser/lexparser/NegraPennCollinizer.java
+++ b/src/edu/stanford/nlp/parser/lexparser/NegraPennCollinizer.java
@@ -12,7 +12,7 @@ import edu.stanford.nlp.trees.TreeFactory;
 import edu.stanford.nlp.trees.TreeTransformer;
 
 
-public class NegraPennCollinizer implements TreeTransformer {
+public class NegraPennCollinizer extends AbstractCollinizer {
 
   /** A logger for this class */
   Redwood.RedwoodChannels log = Redwood.channels(NegraPennCollinizer.class);

--- a/src/edu/stanford/nlp/parser/lexparser/NegraPennTreebankParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/NegraPennTreebankParserParams.java
@@ -125,7 +125,7 @@ public class NegraPennTreebankParserParams extends AbstractTreebankParserParams 
    * returns a NegraPennCollinizer
    */
   @Override
-  public TreeTransformer collinizer() {
+  public AbstractCollinizer collinizer() {
     return new NegraPennCollinizer(this);
   }
 
@@ -133,7 +133,7 @@ public class NegraPennTreebankParserParams extends AbstractTreebankParserParams 
    * returns a NegraPennCollinizer
    */
   @Override
-  public TreeTransformer collinizerEvalb() {
+  public AbstractCollinizer collinizerEvalb() {
     return new NegraPennCollinizer(this, false);
   }
 

--- a/src/edu/stanford/nlp/parser/lexparser/SpanishTreebankParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/SpanishTreebankParserParams.java
@@ -262,12 +262,12 @@ public class SpanishTreebankParserParams extends TregexPoweredTreebankParserPara
   }
 
   @Override
-  public TreeTransformer collinizer() {
+  public AbstractCollinizer collinizer() {
     return new TreeCollinizer(treebankLanguagePack());
   }
 
   @Override
-  public TreeTransformer collinizerEvalb() {
+  public AbstractCollinizer collinizerEvalb() {
     return new TreeCollinizer(treebankLanguagePack());
   }
 

--- a/src/edu/stanford/nlp/parser/lexparser/TreeCollinizer.java
+++ b/src/edu/stanford/nlp/parser/lexparser/TreeCollinizer.java
@@ -17,7 +17,7 @@ import edu.stanford.nlp.trees.*;
  * @author Dan Klein
  * @author Christopher Manning
  */
-public class TreeCollinizer implements TreeTransformer {
+public class TreeCollinizer extends AbstractCollinizer {
 
   private final TreebankLanguagePack tlp;
   private final boolean deletePunct;

--- a/src/edu/stanford/nlp/parser/lexparser/TreeCollinizer.java
+++ b/src/edu/stanford/nlp/parser/lexparser/TreeCollinizer.java
@@ -17,7 +17,7 @@ import edu.stanford.nlp.trees.*;
  * @author Dan Klein
  * @author Christopher Manning
  */
-public class TreeCollinizer extends AbstractCollinizer {
+public class TreeCollinizer implements AbstractCollinizer {
 
   private final TreebankLanguagePack tlp;
   private final boolean deletePunct;

--- a/src/edu/stanford/nlp/parser/lexparser/TreebankLangParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/TreebankLangParserParams.java
@@ -90,7 +90,7 @@ public interface TreebankLangParserParams extends TreebankFactory, Serializable 
    *     or equivalence class things not evaluated in the parser performance
    *     evaluation.
    */
-  TreeTransformer collinizer();
+  AbstractCollinizer collinizer();
 
 
   /**
@@ -100,7 +100,7 @@ public interface TreebankLangParserParams extends TreebankFactory, Serializable 
    * things. The evalb version should strip some more stuff
    * off. (finish this doc!)
    */
-  TreeTransformer collinizerEvalb();
+  AbstractCollinizer collinizerEvalb();
 
   /**
    * returns a MemoryTreebank appropriate to the treebank source

--- a/src/edu/stanford/nlp/parser/lexparser/TueBaDZParserParams.java
+++ b/src/edu/stanford/nlp/parser/lexparser/TueBaDZParserParams.java
@@ -57,12 +57,12 @@ public class TueBaDZParserParams extends AbstractTreebankParserParams  {
   }
 
   @Override
-  public TreeTransformer collinizer() {
+  public AbstractCollinizer collinizer() {
     return new TreeCollinizer(treebankLanguagePack());
   }
 
   @Override
-  public TreeTransformer collinizerEvalb() {
+  public AbstractCollinizer collinizerEvalb() {
     return new TreeCollinizer(treebankLanguagePack());
   }
 

--- a/src/edu/stanford/nlp/parser/metrics/CollinsDepEval.java
+++ b/src/edu/stanford/nlp/parser/metrics/CollinsDepEval.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import edu.stanford.nlp.international.Language;
+import edu.stanford.nlp.parser.lexparser.AbstractCollinizer;
 import edu.stanford.nlp.parser.lexparser.TreebankLangParserParams;
 import edu.stanford.nlp.stats.ClassicCounter;
 import edu.stanford.nlp.stats.Counter;
@@ -20,7 +21,6 @@ import edu.stanford.nlp.trees.CollinsDependency;
 import edu.stanford.nlp.trees.CollinsRelation;
 import edu.stanford.nlp.trees.HeadFinder;
 import edu.stanford.nlp.trees.Tree;
-import edu.stanford.nlp.trees.TreeTransformer;
 import edu.stanford.nlp.trees.Treebank;
 import edu.stanford.nlp.util.Generics;
 import edu.stanford.nlp.util.PropertiesUtils;
@@ -244,7 +244,7 @@ public class CollinsDepEval extends AbstractEval  {
 
     final CollinsDepEval depEval = new CollinsDepEval("CollinsDep", true, tlpp.headFinder(), tlpp.treebankLanguagePack().startSymbol());
 
-    final TreeTransformer tc = tlpp.collinizer();
+    final AbstractCollinizer tc = tlpp.collinizer();
 
     //PennTreeReader skips over null/malformed parses. So when the yields of the gold/guess trees
     //don't match, we need to keep looking for the next gold tree that matches.

--- a/src/edu/stanford/nlp/parser/metrics/CollinsDepEval.java
+++ b/src/edu/stanford/nlp/parser/metrics/CollinsDepEval.java
@@ -262,7 +262,6 @@ public class CollinsDepEval extends AbstractEval  {
     int skippedGuessTrees = 0;
 
     for(final Tree guess : guessTreebank) {
-      final Tree evalGuess = tc.transformTree(guess);
       if(guess.yield().size() > MAX_GUESS_YIELD) {
         skippedGuessTrees++;
         continue;
@@ -271,13 +270,14 @@ public class CollinsDepEval extends AbstractEval  {
       boolean doneEval = false;
       while(goldItr.hasNext() && !doneEval) {
         final Tree gold = goldItr.next();
-        final Tree evalGold = tc.transformTree(gold);
+        final Tree evalGold = tc.transformTree(gold, gold);
         goldLineId++;
 
-        if(gold.yield().size() > MAX_GOLD_YIELD) {
+        if(gold.yield().size() > MAX_GOLD_YIELD)
           continue;
 
-        } else if(evalGold.yield().size() != evalGuess.yield().size()) {
+        final Tree evalGuess = tc.transformTree(guess, gold);
+        if (evalGuess == null || evalGold.yield().size() != evalGuess.yield().size()) {
           pwOut.println("Yield mismatch at gold line " + goldLineId);
           skippedGuessTrees++;
           break; //Default evalb behavior -- skip this guess tree

--- a/src/edu/stanford/nlp/parser/metrics/Evalb.java
+++ b/src/edu/stanford/nlp/parser/metrics/Evalb.java
@@ -18,12 +18,12 @@ import java.util.Set;
 import edu.stanford.nlp.international.Language;
 import edu.stanford.nlp.ling.Label;
 import edu.stanford.nlp.ling.SentenceUtils;
+import edu.stanford.nlp.parser.lexparser.AbstractCollinizer;
 import edu.stanford.nlp.parser.lexparser.TreebankLangParserParams;
 import edu.stanford.nlp.trees.Constituent;
 import edu.stanford.nlp.trees.ConstituentFactory;
 import edu.stanford.nlp.trees.LabeledScoredConstituentFactory;
 import edu.stanford.nlp.trees.Tree;
-import edu.stanford.nlp.trees.TreeTransformer;
 import edu.stanford.nlp.trees.Treebank;
 import edu.stanford.nlp.util.Generics;
 import edu.stanford.nlp.util.PropertiesUtils;
@@ -203,7 +203,7 @@ public class Evalb extends AbstractEval  {
 
     final Evalb metric = new Evalb("Evalb LP/LR", true);
     final EvalbByCat evalbCat = (doCatLevel) ? new EvalbByCat("EvalbByCat LP/LR", true, labelRegex) : null;
-    final TreeTransformer tc = tlpp.collinizer();
+    final AbstractCollinizer tc = tlpp.collinizer();
 
     //The evalb ref implementation assigns status for each tree pair as follows:
     //

--- a/src/edu/stanford/nlp/parser/metrics/Evalb.java
+++ b/src/edu/stanford/nlp/parser/metrics/Evalb.java
@@ -239,8 +239,8 @@ public class Evalb extends AbstractEval  {
         continue;
       }
 
-      final Tree evalGuess = tc.transformTree(guessTree);
-      final Tree evalGold = tc.transformTree(goldTree);
+      final Tree evalGuess = tc.transformTree(guessTree, goldTree);
+      final Tree evalGold = tc.transformTree(goldTree, goldTree);
 
       metric.evaluate(evalGuess, evalGold, ((VERBOSE) ? pwOut : null));
 

--- a/src/edu/stanford/nlp/parser/metrics/EvaluateTreebank.java
+++ b/src/edu/stanford/nlp/parser/metrics/EvaluateTreebank.java
@@ -319,7 +319,7 @@ public class EvaluateTreebank  {
           int sz = parses.size();
           if (sz > 1) {
             pwOut.println("There were " + sz + " best PCFG parses with score " + parses.get(0).score() + '.');
-            Tree transGoldTree = collinizer.transformTree(goldTree);
+            Tree transGoldTree = collinizer.transformTree(goldTree, goldTree);
             int iii = 0;
             for (ScoredObject<Tree> sot : parses) {
               iii++;
@@ -329,7 +329,7 @@ public class EvaluateTreebank  {
               pq.restoreOriginalWords(tbd);
               pwOut.println("PCFG Parse #" + iii + " with score " + tbd.score());
               tbd.pennPrint(pwOut);
-              Tree tbtr = collinizer.transformTree(tbd);
+              Tree tbtr = collinizer.transformTree(tbd, goldTree);
               // pwOut.println("Tree size = " + tbtr.size() + "; depth = " + tbtr.depth());
               kGoodLB.evaluate(tbtr, transGoldTree, pwErr);
             }
@@ -338,14 +338,14 @@ public class EvaluateTreebank  {
         // Huang and Chiang (2006) Algorithm 3 output from the PCFG parser
         else if (op.testOptions.printPCFGkBest > 0 && op.testOptions.outputkBestEquivocation == null) {
           List<ScoredObject<Tree>> trees = kbestPCFGTrees.subList(0, op.testOptions.printPCFGkBest);
-          Tree transGoldTree = collinizer.transformTree(goldTree);
+          Tree transGoldTree = collinizer.transformTree(goldTree, goldTree);
           int i = 0;
           for (ScoredObject<Tree> tp : trees) {
             i++;
             pwOut.println("PCFG Parse #" + i + " with score " + tp.score());
             Tree tbd = tp.object();
             tbd.pennPrint(pwOut);
-            Tree tbtr = collinizer.transformTree(tbd);
+            Tree tbtr = collinizer.transformTree(tbd, goldTree);
             kGoodLB.evaluate(tbtr, transGoldTree, pwErr);
           }
         }
@@ -353,14 +353,14 @@ public class EvaluateTreebank  {
         else if (op.testOptions.printFactoredKGood > 0 && pq.hasFactoredParse()) {
           // DZ: debug n best trees
           List<ScoredObject<Tree>> trees = pq.getKGoodFactoredParses(op.testOptions.printFactoredKGood);
-          Tree transGoldTree = collinizer.transformTree(goldTree);
+          Tree transGoldTree = collinizer.transformTree(goldTree, goldTree);
           int ii = 0;
           for (ScoredObject<Tree> tp : trees) {
             ii++;
             pwOut.println("Factored Parse #" + ii + " with score " + tp.score());
             Tree tbd = tp.object();
             tbd.pennPrint(pwOut);
-            Tree tbtr = collinizer.transformTree(tbd);
+            Tree tbtr = collinizer.transformTree(tbd, goldTree);
             kGoodLB.evaluate(tbtr, transGoldTree, pwOut);
           }
         }
@@ -396,14 +396,14 @@ public class EvaluateTreebank  {
       if (tree != null) {
         //Strip subcategories and remove punctuation for evaluation
         tree = subcategoryStripper.transformTree(tree);
-        Tree treeFact = collinizer.transformTree(tree);
+        Tree treeFact = collinizer.transformTree(tree, goldTree);
 
         //Setup the gold tree
         if (op.testOptions.verbose) {
           pwOut.println("Correct parse");
           treePrint.printTree(goldTree, pwOut);
         }
-        Tree transGoldTree = collinizer.transformTree(goldTree);
+        Tree transGoldTree = collinizer.transformTree(goldTree, goldTree);
         if(transGoldTree != null)
           transGoldTree = subcategoryStripper.transformTree(transGoldTree);
 
@@ -436,7 +436,7 @@ public class EvaluateTreebank  {
           List<Tree> transGuesses = new ArrayList<>();
           int kbest = Math.min(op.testOptions.evalPCFGkBest, kbestPCFGTrees.size());
           for (ScoredObject<Tree> guess : kbestPCFGTrees.subList(0, kbest)) {
-            transGuesses.add(collinizer.transformTree(guess.object()));
+            transGuesses.add(collinizer.transformTree(guess.object(), goldTree));
           }
           for (BestOfTopKEval eval : topKEvals) {
             eval.evaluate(transGuesses, transGoldTree, pwErr);
@@ -446,7 +446,7 @@ public class EvaluateTreebank  {
         //PCFG eval
         Tree treePCFG = pq.getBestPCFGParse();
         if (treePCFG != null) {
-          Tree treePCFGeval = collinizer.transformTree(treePCFG);
+          Tree treePCFGeval = collinizer.transformTree(treePCFG, goldTree);
           if (pcfgLB != null) {
             pcfgLB.evaluate(treePCFGeval, transGoldTree, pwErr);
           }

--- a/src/edu/stanford/nlp/parser/metrics/EvaluateTreebank.java
+++ b/src/edu/stanford/nlp/parser/metrics/EvaluateTreebank.java
@@ -22,6 +22,7 @@ import edu.stanford.nlp.parser.common.ParserQuery;
 import edu.stanford.nlp.parser.common.ParserQueryFactory;
 import edu.stanford.nlp.parser.common.ParserUtils;
 import edu.stanford.nlp.parser.common.ParsingThreadsafeProcessor;
+import edu.stanford.nlp.parser.lexparser.AbstractCollinizer;
 import edu.stanford.nlp.parser.lexparser.BoundaryRemover;
 import edu.stanford.nlp.parser.lexparser.Debinarizer;
 import edu.stanford.nlp.parser.lexparser.LexicalizedParser;
@@ -50,7 +51,7 @@ public class EvaluateTreebank  {
   private final Options op;
   private final TreeTransformer debinarizer;
   private final TreeTransformer subcategoryStripper;
-  private final TreeTransformer collinizer;
+  private final AbstractCollinizer collinizer;
   private final TreeTransformer boundaryRemover;
 
   private final ParserQueryFactory pqFactory;

--- a/src/edu/stanford/nlp/parser/metrics/LeafAncestorEval.java
+++ b/src/edu/stanford/nlp/parser/metrics/LeafAncestorEval.java
@@ -373,8 +373,8 @@ public class LeafAncestorEval  {
         continue;
       }
 
-      final Tree evalGuess = tc.transformTree(guessTree);
-      final Tree evalGold = tc.transformTree(goldTree);
+      final Tree evalGuess = tc.transformTree(guessTree, goldTree);
+      final Tree evalGold = tc.transformTree(goldTree, goldTree);
 
       metric.evaluate(evalGuess, evalGold, ((VERBOSE) ? pwOut : null));
     }

--- a/src/edu/stanford/nlp/parser/metrics/LeafAncestorEval.java
+++ b/src/edu/stanford/nlp/parser/metrics/LeafAncestorEval.java
@@ -15,9 +15,9 @@ import edu.stanford.nlp.international.Language;
 import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.ling.HasIndex;
 import edu.stanford.nlp.ling.Label;
+import edu.stanford.nlp.parser.lexparser.AbstractCollinizer;
 import edu.stanford.nlp.parser.lexparser.TreebankLangParserParams;
 import edu.stanford.nlp.trees.Tree;
-import edu.stanford.nlp.trees.TreeTransformer;
 import edu.stanford.nlp.trees.Treebank;
 import edu.stanford.nlp.util.Generics;
 import edu.stanford.nlp.util.StringUtils;
@@ -337,7 +337,7 @@ public class LeafAncestorEval  {
 
     final LeafAncestorEval metric = new LeafAncestorEval("LeafAncestor");
 
-    final TreeTransformer tc = tlpp.collinizer();
+    final AbstractCollinizer tc = tlpp.collinizer();
 
     //The evalb ref implementation assigns status for each tree pair as follows:
     //

--- a/src/edu/stanford/nlp/parser/metrics/TaggingEval.java
+++ b/src/edu/stanford/nlp/parser/metrics/TaggingEval.java
@@ -15,13 +15,13 @@ import edu.stanford.nlp.international.Language;
 import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.ling.HasTag;
 import edu.stanford.nlp.ling.Label;
+import edu.stanford.nlp.parser.lexparser.AbstractCollinizer;
 import edu.stanford.nlp.parser.lexparser.EnglishTreebankParserParams;
 import edu.stanford.nlp.parser.lexparser.Lexicon;
 import edu.stanford.nlp.parser.lexparser.TreebankLangParserParams;
 import edu.stanford.nlp.stats.ClassicCounter;
 import edu.stanford.nlp.stats.Counter;
 import edu.stanford.nlp.trees.Tree;
-import edu.stanford.nlp.trees.TreeTransformer;
 import edu.stanford.nlp.trees.Treebank;
 import edu.stanford.nlp.util.Generics;
 import edu.stanford.nlp.util.StringUtils;
@@ -321,7 +321,7 @@ public class TaggingEval extends AbstractEval  {
 
     final TaggingEval metric = new TaggingEval("Tagging LP/LR");
 
-    final TreeTransformer tc = tlpp.collinizer();
+    final AbstractCollinizer tc = tlpp.collinizer();
 
     //The evalb ref implementation assigns status for each tree pair as follows:
     //

--- a/src/edu/stanford/nlp/parser/metrics/TaggingEval.java
+++ b/src/edu/stanford/nlp/parser/metrics/TaggingEval.java
@@ -357,8 +357,8 @@ public class TaggingEval extends AbstractEval  {
         continue;
       }
 
-      final Tree evalGuess = tc.transformTree(guessTree);
-      final Tree evalGold = tc.transformTree(goldTree);
+      final Tree evalGuess = tc.transformTree(guessTree, goldTree);
+      final Tree evalGold = tc.transformTree(goldTree, goldTree);
 
       metric.evaluate(evalGuess, evalGold, ((VERBOSE) ? pwOut : null));
     }

--- a/src/edu/stanford/nlp/parser/metrics/TsarfatyEval.java
+++ b/src/edu/stanford/nlp/parser/metrics/TsarfatyEval.java
@@ -8,13 +8,13 @@ import java.util.Set;
 import edu.stanford.nlp.international.Language;
 import edu.stanford.nlp.ling.Label;
 import edu.stanford.nlp.ling.SentenceUtils;
+import edu.stanford.nlp.parser.lexparser.AbstractCollinizer;
 import edu.stanford.nlp.parser.lexparser.EnglishTreebankParserParams;
 import edu.stanford.nlp.parser.lexparser.TreebankLangParserParams;
 import edu.stanford.nlp.trees.Constituent;
 import edu.stanford.nlp.trees.ConstituentFactory;
 import edu.stanford.nlp.trees.LabeledScoredConstituentFactory;
 import edu.stanford.nlp.trees.Tree;
-import edu.stanford.nlp.trees.TreeTransformer;
 import edu.stanford.nlp.trees.Treebank;
 import edu.stanford.nlp.util.Generics;
 
@@ -156,7 +156,7 @@ public class TsarfatyEval extends AbstractEval {
     final String evalName = (tagMode) ? "TsarfatyTAG" : "TsarfatySEG";
     final TsarfatyEval eval = new TsarfatyEval(evalName, tagMode);
 
-    final TreeTransformer tc = tlpp.collinizer();
+    final AbstractCollinizer tc = tlpp.collinizer();
 
     //PennTreeReader skips over null/malformed parses. So when the yields of the gold/guess trees
     //don't match, we need to keep looking for the next gold tree that matches.

--- a/src/edu/stanford/nlp/parser/metrics/UnlabeledAttachmentEval.java
+++ b/src/edu/stanford/nlp/parser/metrics/UnlabeledAttachmentEval.java
@@ -10,12 +10,12 @@ import java.util.Set;
 import edu.stanford.nlp.international.Language;
 import edu.stanford.nlp.ling.Label;
 import edu.stanford.nlp.ling.SentenceUtils;
+import edu.stanford.nlp.parser.lexparser.AbstractCollinizer;
 import edu.stanford.nlp.parser.lexparser.EnglishTreebankParserParams;
 import edu.stanford.nlp.parser.lexparser.TreebankLangParserParams;
 import edu.stanford.nlp.trees.Dependency;
 import edu.stanford.nlp.trees.HeadFinder;
 import edu.stanford.nlp.trees.Tree;
-import edu.stanford.nlp.trees.TreeTransformer;
 import edu.stanford.nlp.trees.Treebank;
 import java.util.function.Predicate;
 import edu.stanford.nlp.util.Filters;
@@ -180,7 +180,7 @@ public class UnlabeledAttachmentEval extends AbstractEval  {
 
     final UnlabeledAttachmentEval metric = new UnlabeledAttachmentEval("UAS LP/LR", true, tlpp.headFinder());
 
-    final TreeTransformer tc = tlpp.collinizer();
+    final AbstractCollinizer tc = tlpp.collinizer();
 
     //The evalb ref implementation assigns status for each tree pair as follows:
     //

--- a/src/edu/stanford/nlp/parser/metrics/UnlabeledAttachmentEval.java
+++ b/src/edu/stanford/nlp/parser/metrics/UnlabeledAttachmentEval.java
@@ -216,9 +216,9 @@ public class UnlabeledAttachmentEval extends AbstractEval  {
         continue;
       }
 
-      final Tree evalGuess = tc.transformTree(guessTree);
+      final Tree evalGuess = tc.transformTree(guessTree, goldTree);
       evalGuess.indexLeaves(true);
-      final Tree evalGold = tc.transformTree(goldTree);
+      final Tree evalGold = tc.transformTree(goldTree, goldTree);
       evalGold.indexLeaves(true);
 
       metric.evaluate(evalGuess, evalGold, ((VERBOSE) ? pwOut : null));

--- a/src/edu/stanford/nlp/trees/international/pennchinese/ChineseCollinizer.java
+++ b/src/edu/stanford/nlp/trees/international/pennchinese/ChineseCollinizer.java
@@ -66,18 +66,22 @@ public class ChineseCollinizer implements AbstractCollinizer  {
 
     // log.info("ChineseCollinizer: Node label is " + label);
 
-    // TODO: use the gold tree to delete the same punct from both trees
-    if (guess.isLeaf()) {
-      if (deletePunct && ctlp.isPunctuationWord(label)) {
+    // Eliminate unwanted (in terms of evaluation) punctuation
+    // by comparing the gold punctuation, not the guess tree
+    // This way, retagging does not change the results
+    if (guess.isPreTerminal() && deletePunct) {
+      Tree goldPT = goldPreterminals.next();
+      if (ctlp.isPunctuationTag(goldPT.label().value()) ||
+          ctlp.isPunctuationWord(goldPT.firstChild().label().value())) {
+        // System.out.println("Deleting punctuation");
         return null;
-      } else {
-        return tf.newLeaf(new StringLabel(label));
       }
     }
-    if (guess.isPreTerminal() && deletePunct && ctlp.isPunctuationTag(label)) {
-      // System.out.println("Deleting punctuation");
-      return null;
+
+    if (guess.isLeaf()) {
+      return tf.newLeaf(new StringLabel(label));
     }
+
     List<Tree> children = new ArrayList<>();
 
     if (label.matches("ROOT.*") && guess.numChildren() == 1) { // keep non-unary roots for now

--- a/src/edu/stanford/nlp/trees/international/pennchinese/ChineseCollinizer.java
+++ b/src/edu/stanford/nlp/trees/international/pennchinese/ChineseCollinizer.java
@@ -23,7 +23,7 @@ import java.util.List;
  * @author Roger Levy
  * @author Christopher Manning
  */
-public class ChineseCollinizer extends AbstractCollinizer  {
+public class ChineseCollinizer implements AbstractCollinizer  {
 
   /** A logger for this class */
   private static Redwood.RedwoodChannels log = Redwood.channels(ChineseCollinizer.class);

--- a/src/edu/stanford/nlp/trees/international/pennchinese/ChineseCollinizer.java
+++ b/src/edu/stanford/nlp/trees/international/pennchinese/ChineseCollinizer.java
@@ -2,10 +2,10 @@ package edu.stanford.nlp.trees.international.pennchinese;
 import edu.stanford.nlp.util.logging.Redwood;
 
 import edu.stanford.nlp.ling.StringLabel;
+import edu.stanford.nlp.parser.lexparser.AbstractCollinizer;
 import edu.stanford.nlp.trees.LabeledScoredTreeFactory;
 import edu.stanford.nlp.trees.Tree;
 import edu.stanford.nlp.trees.TreeFactory;
-import edu.stanford.nlp.trees.TreeTransformer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
  * @author Roger Levy
  * @author Christopher Manning
  */
-public class ChineseCollinizer implements TreeTransformer  {
+public class ChineseCollinizer extends AbstractCollinizer  {
 
   /** A logger for this class */
   private static Redwood.RedwoodChannels log = Redwood.channels(ChineseCollinizer.class);

--- a/test/src/edu/stanford/nlp/parser/lexparser/NegraPennCollinizerTest.java
+++ b/test/src/edu/stanford/nlp/parser/lexparser/NegraPennCollinizerTest.java
@@ -1,0 +1,42 @@
+package edu.stanford.nlp.parser.lexparser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import edu.stanford.nlp.trees.Tree;
+
+public class NegraPennCollinizerTest {
+  @Test
+  public void testRemovePunct() {
+    NegraPennTreebankParserParams tlpp = new NegraPennTreebankParserParams();
+    NegraPennCollinizer collinizer = new NegraPennCollinizer(tlpp);
+
+    // Test that the collinizer removes a comma
+    // Lazy test writing: just use the English version, updated to work with the German tags
+    Tree gold = Tree.valueOf("(ROOT (S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) ($, ,) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie))))))");
+    Tree goldT = collinizer.transformTree(gold, gold);
+    Tree goldExpected = Tree.valueOf("(S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie)))))");
+    Assert.assertEquals(goldExpected, goldT);
+
+    // Same test, but it should pick up the comma just based on the tag
+    gold = Tree.valueOf("(ROOT (S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) ($, zzzzz) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie))))))");
+    goldT = collinizer.transformTree(gold, gold);
+    Assert.assertEquals(goldExpected, goldT);
+
+    // Difference with the English: the Negra collinizer does not look at punct words
+    // Perhaps that was a mistake?
+    gold = Tree.valueOf("(S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (CC ,) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie)))))");
+    goldT = collinizer.transformTree(gold, gold);
+    Assert.assertEquals(gold, goldT);
+
+    // Double check that (CC zzzzz) is not deleted by default
+    Tree guess = Tree.valueOf("(S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (CC zzzzz) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie)))))");
+    Tree guessT = collinizer.transformTree(guess, guess);
+    Assert.assertEquals(guess, guessT);
+
+    // Check that the guess tree has the non-punct word removed if it is a punct in the gold tree
+    gold = Tree.valueOf("(ROOT (S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) ($, zzzzz) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie))))))");
+    guessT = collinizer.transformTree(guess, gold);
+    Assert.assertEquals(goldExpected, guessT);
+  }
+}

--- a/test/src/edu/stanford/nlp/parser/lexparser/TreeCollinizerTest.java
+++ b/test/src/edu/stanford/nlp/parser/lexparser/TreeCollinizerTest.java
@@ -1,0 +1,40 @@
+package edu.stanford.nlp.parser.lexparser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import edu.stanford.nlp.trees.PennTreebankLanguagePack;
+import edu.stanford.nlp.trees.Tree;
+
+public class TreeCollinizerTest {
+  @Test
+  public void testRemovePunct() {
+    PennTreebankLanguagePack tlp = new PennTreebankLanguagePack();
+    TreeCollinizer collinizer = new TreeCollinizer(tlp);
+
+    // Test that the collinizer removes a comma
+    Tree gold = Tree.valueOf("(ROOT (S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (, ,) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie))))))");
+    Tree goldT = collinizer.transformTree(gold, gold);
+    Tree goldExpected = Tree.valueOf("(S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie)))))");
+    Assert.assertEquals(goldExpected, goldT);
+
+    // Same test, but it should pick up the comma just based on the tag
+    gold = Tree.valueOf("(ROOT (S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (, zzzzz) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie))))))");
+    goldT = collinizer.transformTree(gold, gold);
+    Assert.assertEquals(goldExpected, goldT);
+
+    // It should also pick up the comma based on the word
+    gold = Tree.valueOf("(S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (CC ,) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie)))))");
+    goldT = collinizer.transformTree(gold, gold);
+    Assert.assertEquals(goldExpected, goldT);
+
+    // Double check that (CC zzzzz) is not deleted by default
+    Tree guess = Tree.valueOf("(S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (CC zzzzz) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie)))))");
+    Tree guessT = collinizer.transformTree(guess, guess);
+    Assert.assertEquals(guess, guessT);
+
+    // Check that the guess tree has the non-punct word removed if it is a punct in the gold tree
+    guessT = collinizer.transformTree(guess, gold);
+    Assert.assertEquals(goldExpected, guessT);
+  }
+}

--- a/test/src/edu/stanford/nlp/trees/international/pennchinese/ChineseCollinizerTest.java
+++ b/test/src/edu/stanford/nlp/trees/international/pennchinese/ChineseCollinizerTest.java
@@ -1,0 +1,41 @@
+package edu.stanford.nlp.trees.international.pennchinese;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import edu.stanford.nlp.trees.Tree;
+import edu.stanford.nlp.trees.international.pennchinese.ChineseTreebankLanguagePack;
+
+public class ChineseCollinizerTest {
+  @Test
+  public void testRemovePunct() {
+    ChineseTreebankLanguagePack tlp = new ChineseTreebankLanguagePack();
+    ChineseCollinizer collinizer = new ChineseCollinizer(tlp);
+
+    // Test that the collinizer removes a comma
+    // Lazy test writing: just use the English version, updated to work with the Chinese tags
+    Tree gold = Tree.valueOf("(ROOT (S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (PU ,) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie))))))");
+    Tree goldT = collinizer.transformTree(gold, gold);
+    Tree goldExpected = Tree.valueOf("(S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie)))))");
+    Assert.assertEquals(goldExpected, goldT);
+
+    // Same test, but it should pick up the comma just based on the tag
+    gold = Tree.valueOf("(ROOT (S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (PU zzzzz) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie))))))");
+    goldT = collinizer.transformTree(gold, gold);
+    Assert.assertEquals(goldExpected, goldT);
+
+    // It should also pick up the comma based on the word
+    gold = Tree.valueOf("(S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (CC ,) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie)))))");
+    goldT = collinizer.transformTree(gold, gold);
+    Assert.assertEquals(goldExpected, goldT);
+
+    // Double check that (CC zzzzz) is not deleted by default
+    Tree guess = Tree.valueOf("(S (S (NP (PRP I)) (VP (VBP like) (NP (JJ blue) (NN skin)))) (CC zzzzz) (CC and) (S (NP (PRP I)) (VP (MD cannot) (VP (VB lie)))))");
+    Tree guessT = collinizer.transformTree(guess, guess);
+    Assert.assertEquals(guess, guessT);
+
+    // Check that the guess tree has the non-punct word removed if it is a punct in the gold tree
+    guessT = collinizer.transformTree(guess, gold);
+    Assert.assertEquals(goldExpected, guessT);
+  }
+}


### PR DESCRIPTION
Update the collinizer to delete words based on the gold tags, not the guess tags, in case the POS tagger disagrees with the original treebank on which words are symbols vs punct