### PR TITLE
Remove extra non-matching right parentheses

### DIFF
--- a/test/src/edu/stanford/nlp/trees/tregex/TregexTest.java
+++ b/test/src/edu/stanford/nlp/trees/tregex/TregexTest.java
@@ -497,13 +497,13 @@ public class TregexTest extends TestCase {
     runTest("foo <: bar", "(foo (bar 1))", "(foo (bar 1))");
     runTest("foo <: bar", "(foo (bar 1) (bar 2))");
     runTest("foo <: bar", "(foo)");
-    runTest("foo <: bar", "(foo (baz (bar))))");
+    runTest("foo <: bar", "(foo (baz (bar)))");
     runTest("foo <: bar", "(foo 1)");
 
     runTest("bar >: foo", "(foo (bar 1))", "(bar 1)");
     runTest("bar >: foo", "(foo (bar 1) (bar 2))");
     runTest("bar >: foo", "(foo)");
-    runTest("bar >: foo", "(foo (baz (bar))))");
+    runTest("bar >: foo", "(foo (baz (bar)))");
     runTest("bar >: foo", "(bar (foo 1))");
 
     runTest("/.*/ >: foo", "(a (foo (bar 1)) (foo (baz 2)))",


### PR DESCRIPTION
This PR fixes [#1372](https://github.com/stanfordnlp/CoreNLP/issues/1372). It removes two extra non-matching right parentheses in TregexTest.java.

Issue: [Extra non-matching right parenthesis in TregexTest.java #1372](https://github.com/stanfordnlp/CoreNLP/issues/1372 )