### PR TITLE
Ssurgeon edit features

### DIFF
--- a/src/edu/stanford/nlp/ling/CoreAnnotations.java
+++ b/src/edu/stanford/nlp/ling/CoreAnnotations.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
+import java.util.TreeMap;
 
 /**
  * Set of common annotations for {@link CoreMap}s. The classes
@@ -580,10 +581,10 @@ public class CoreAnnotations {
   /**
    * CoNLL-U dep parsing - List of morphological features
    */
-  public static class CoNLLUFeats implements CoreAnnotation<HashMap<String,String>> {
+  public static class CoNLLUFeats implements CoreAnnotation<TreeMap<String,String>> {
     @Override
-    public Class<HashMap<String,String>> getType() {
-      return ErasureUtils.uncheckedCast(HashMap.class);
+    public Class<TreeMap<String,String>> getType() {
+      return ErasureUtils.uncheckedCast(TreeMap.class);
     }
   }
 

--- a/src/edu/stanford/nlp/ling/CoreAnnotations.java
+++ b/src/edu/stanford/nlp/ling/CoreAnnotations.java
@@ -1,6 +1,7 @@
 package edu.stanford.nlp.ling;
 
 import edu.stanford.nlp.ie.util.RelationTriple;
+import edu.stanford.nlp.trees.ud.CoNLLUFeatures;
 import edu.stanford.nlp.util.*;
 
 import java.util.Calendar;
@@ -581,10 +582,10 @@ public class CoreAnnotations {
   /**
    * CoNLL-U dep parsing - List of morphological features
    */
-  public static class CoNLLUFeats implements CoreAnnotation<TreeMap<String,String>> {
+  public static class CoNLLUFeats implements CoreAnnotation<CoNLLUFeatures> {
     @Override
-    public Class<TreeMap<String,String>> getType() {
-      return ErasureUtils.uncheckedCast(TreeMap.class);
+    public Class<CoNLLUFeatures> getType() {
+      return CoNLLUFeatures.class;
     }
   }
 

--- a/src/edu/stanford/nlp/ling/CoreLabel.java
+++ b/src/edu/stanford/nlp/ling/CoreLabel.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 
-import edu.stanford.nlp.trees.ud.CoNLLUUtils;
+import edu.stanford.nlp.trees.ud.CoNLLUFeatures;
 import edu.stanford.nlp.util.ArrayCoreMap;
 import edu.stanford.nlp.util.CoreMap;
 import edu.stanford.nlp.util.Generics;
@@ -201,7 +201,7 @@ public class CoreLabel extends ArrayCoreMap implements AbstractCoreLabel, HasCat
           } else if (valueClass == Boolean.class) {
             this.set(coreKeyClass, Boolean.parseBoolean(values[i]));
           } else if (coreKeyClass == CoreAnnotations.CoNLLUFeats.class) {
-            this.set(coreKeyClass, CoNLLUUtils.parseFeatures(values[i]));
+            this.set(coreKeyClass, new CoNLLUFeatures(values[i]));
           } else {
             throw new UnsupportedOperationException("CORE: CoreLabel.initFromStrings: " +
                                                     "Can't handle " + valueClass + " (key " + key + ")");
@@ -254,7 +254,7 @@ public class CoreLabel extends ArrayCoreMap implements AbstractCoreLabel, HasCat
         } else if (valueClass == Boolean.class) {
           this.set(coreKeyClass, Boolean.parseBoolean(values[i]));
         } else if (coreKeyClass == CoreAnnotations.CoNLLUFeats.class) {
-          this.set(coreKeyClass, CoNLLUUtils.parseFeatures(values[i]));
+          this.set(coreKeyClass, new CoNLLUFeatures(values[i]));
         } else {
           throw new UnsupportedOperationException("CORE: CoreLabel.initFromStrings: " +
                                                   "Can't handle " + valueClass + " (key " + coreKeyClass + ")");

--- a/src/edu/stanford/nlp/pipeline/ProtobufAnnotationSerializer.java
+++ b/src/edu/stanford/nlp/pipeline/ProtobufAnnotationSerializer.java
@@ -1453,7 +1453,7 @@ public class ProtobufAnnotationSerializer extends AnnotationSerializer {
     if (proto.hasSpan()) { word.set(SpanAnnotation.class, new IntPair(proto.getSpan().getBegin(), proto.getSpan().getEnd())); }
     if (proto.hasSentiment()) { word.set(SentimentCoreAnnotations.SentimentClass.class, proto.getSentiment()); }
     if (proto.hasQuotationIndex()) { word.set(QuotationIndexAnnotation.class, proto.getQuotationIndex()); }
-    if (proto.hasConllUFeatures()) { word.set(CoNLLUFeats.class, fromProto(proto.getConllUFeatures())); }
+    if (proto.hasConllUFeatures()) { word.set(CoNLLUFeats.class, new TreeMap<>(fromProto(proto.getConllUFeatures()))); }
     if (proto.hasConllUMisc()) { word.set(CoNLLUMisc.class, proto.getConllUMisc()); }
     if (proto.hasCoarseTag()) { word.set(CoarseTagAnnotation.class, proto.getCoarseTag()); }
     if (proto.hasConllUTokenSpan()) { word.set(CoNLLUTokenSpanAnnotation.class, new IntPair(proto.getConllUTokenSpan().getBegin(), proto.getSpan().getEnd())); }

--- a/src/edu/stanford/nlp/pipeline/ProtobufAnnotationSerializer.java
+++ b/src/edu/stanford/nlp/pipeline/ProtobufAnnotationSerializer.java
@@ -25,6 +25,7 @@ import edu.stanford.nlp.trees.GrammaticalRelation;
 import edu.stanford.nlp.trees.LabeledScoredTreeNode;
 import edu.stanford.nlp.trees.Tree;
 import edu.stanford.nlp.trees.Trees;
+import edu.stanford.nlp.trees.ud.CoNLLUFeatures;
 import edu.stanford.nlp.util.*;
 import edu.stanford.nlp.ling.CoreAnnotations;
 import edu.stanford.nlp.ling.CoreAnnotations.*;
@@ -1453,7 +1454,7 @@ public class ProtobufAnnotationSerializer extends AnnotationSerializer {
     if (proto.hasSpan()) { word.set(SpanAnnotation.class, new IntPair(proto.getSpan().getBegin(), proto.getSpan().getEnd())); }
     if (proto.hasSentiment()) { word.set(SentimentCoreAnnotations.SentimentClass.class, proto.getSentiment()); }
     if (proto.hasQuotationIndex()) { word.set(QuotationIndexAnnotation.class, proto.getQuotationIndex()); }
-    if (proto.hasConllUFeatures()) { word.set(CoNLLUFeats.class, new TreeMap<>(fromProto(proto.getConllUFeatures()))); }
+    if (proto.hasConllUFeatures()) { word.set(CoNLLUFeats.class, new CoNLLUFeatures(fromProto(proto.getConllUFeatures()))); }
     if (proto.hasConllUMisc()) { word.set(CoNLLUMisc.class, proto.getConllUMisc()); }
     if (proto.hasCoarseTag()) { word.set(CoarseTagAnnotation.class, proto.getCoarseTag()); }
     if (proto.hasConllUTokenSpan()) { word.set(CoNLLUTokenSpanAnnotation.class, new IntPair(proto.getConllUTokenSpan().getBegin(), proto.getSpan().getEnd())); }

--- a/src/edu/stanford/nlp/semgraph/semgrex/ssurgeon/EditNode.java
+++ b/src/edu/stanford/nlp/semgraph/semgrex/ssurgeon/EditNode.java
@@ -1,7 +1,6 @@
 package edu.stanford.nlp.semgraph.semgrex.ssurgeon;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -94,10 +93,10 @@ public class EditNode extends SsurgeonEdit {
     }
 
     for (String key : updateMorphoFeatures.keySet()) {
-      HashMap<String, String> features = word.get(CoreAnnotations.CoNLLUFeats.class);
+      TreeMap<String, String> features = word.get(CoreAnnotations.CoNLLUFeats.class);
       if (features == null) {
         changed = true;
-        features = new HashMap<>();
+        features = new TreeMap<>();
         word.set(CoreAnnotations.CoNLLUFeats.class, features);
       }
 

--- a/src/edu/stanford/nlp/semgraph/semgrex/ssurgeon/EditNode.java
+++ b/src/edu/stanford/nlp/semgraph/semgrex/ssurgeon/EditNode.java
@@ -9,7 +9,7 @@ import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.ling.IndexedWord;
 import edu.stanford.nlp.semgraph.SemanticGraph;
 import edu.stanford.nlp.semgraph.semgrex.SemgrexMatcher;
-import edu.stanford.nlp.trees.ud.CoNLLUUtils;
+import edu.stanford.nlp.trees.ud.CoNLLUFeatures;
 
 /**
  * Edit an existing node to have new attributes.
@@ -34,7 +34,7 @@ public class EditNode extends SsurgeonEdit {
     this.nodeName = nodeName;
     this.attributes = new TreeMap<>(attributes);
     if (updateMorphoFeatures != null) {
-      this.updateMorphoFeatures = CoNLLUUtils.parseFeatures(updateMorphoFeatures);
+      this.updateMorphoFeatures = new CoNLLUFeatures(updateMorphoFeatures);
     } else {
       this.updateMorphoFeatures = Collections.emptyMap();
     }
@@ -63,7 +63,7 @@ public class EditNode extends SsurgeonEdit {
     if (this.updateMorphoFeatures.size() > 0) {
       buf.append(Ssurgeon.UPDATE_MORPHO_FEATURES);
       buf.append(" ");
-      buf.append(CoNLLUUtils.toFeatureString(this.updateMorphoFeatures));
+      buf.append(CoNLLUFeatures.toFeatureString(this.updateMorphoFeatures));
     }
 
     return buf.toString();
@@ -93,10 +93,10 @@ public class EditNode extends SsurgeonEdit {
     }
 
     for (String key : updateMorphoFeatures.keySet()) {
-      TreeMap<String, String> features = word.get(CoreAnnotations.CoNLLUFeats.class);
+      CoNLLUFeatures features = word.get(CoreAnnotations.CoNLLUFeats.class);
       if (features == null) {
         changed = true;
-        features = new TreeMap<>();
+        features = new CoNLLUFeatures();
         word.set(CoreAnnotations.CoNLLUFeats.class, features);
       }
 

--- a/src/edu/stanford/nlp/semgraph/semgrex/ssurgeon/Ssurgeon.java
+++ b/src/edu/stanford/nlp/semgraph/semgrex/ssurgeon/Ssurgeon.java
@@ -397,6 +397,7 @@ public class Ssurgeon  {
   public static final String WEIGHT_ARG = "-weight";
   public static final String NAME_ARG = "-name";
   public static final String POSITION_ARG = "-position";
+  public static final String UPDATE_MORPHO_FEATURES = "-updateMorphoFeatures";
 
 
   // args for Ssurgeon edits, allowing us to not
@@ -421,6 +422,8 @@ public class Ssurgeon  {
     public String name = null;
 
     public String position = null;
+
+    public String updateMorphoFeatures = null;
 
     public Map<String, String> annotations = new TreeMap<>();
   }
@@ -492,6 +495,9 @@ public class Ssurgeon  {
         case POSITION_ARG:
           argsBox.position = argsValue;
           break;
+        case UPDATE_MORPHO_FEATURES:
+          argsBox.updateMorphoFeatures = argsValue;
+          break;
         default:
           String key = argsKey.substring(1);
           Class<? extends CoreAnnotation<?>> annotation = AnnotationLookup.toCoreKey(key);
@@ -557,7 +563,7 @@ public class Ssurgeon  {
         if (argsBox.nodes.size() != 1) {
           throw new SsurgeonParseException("Cannot make an EditNode out of " + argsBox.nodes.size() + " nodes.  Please use exactly one -node");
         }
-        return new EditNode(argsBox.nodes.get(0), argsBox.annotations);
+        return new EditNode(argsBox.nodes.get(0), argsBox.annotations, argsBox.updateMorphoFeatures);
       } else if (command.equalsIgnoreCase(MergeNodes.LABEL)) {
         if (argsBox.nodes.size() < 2) {
           throw new SsurgeonParseException("Cannot make a MergeNodes out of fewer than 2 nodes (got " + argsBox.nodes.size() + ")");

--- a/src/edu/stanford/nlp/trees/ud/CoNLLUDocumentReader.java
+++ b/src/edu/stanford/nlp/trees/ud/CoNLLUDocumentReader.java
@@ -245,7 +245,7 @@ public class CoNLLUDocumentReader implements
 
 
         /* Parse features. */
-        HashMap<String, String> features = CoNLLUUtils.parseFeatures(bits[5]);
+        TreeMap<String, String> features = CoNLLUUtils.parseFeatures(bits[5]);
         word.set(CoreAnnotations.CoNLLUFeats.class, features);
 
 
@@ -268,7 +268,7 @@ public class CoNLLUDocumentReader implements
         word.setValue(bits[1]);
 
         /* Parse features. */
-        HashMap<String, String> features = CoNLLUUtils.parseFeatures(bits[5]);
+        TreeMap<String, String> features = CoNLLUUtils.parseFeatures(bits[5]);
         word.set(CoreAnnotations.CoNLLUFeats.class, features);
 
         /* Parse extra dependencies. */

--- a/src/edu/stanford/nlp/trees/ud/CoNLLUDocumentReader.java
+++ b/src/edu/stanford/nlp/trees/ud/CoNLLUDocumentReader.java
@@ -245,7 +245,7 @@ public class CoNLLUDocumentReader implements
 
 
         /* Parse features. */
-        TreeMap<String, String> features = CoNLLUUtils.parseFeatures(bits[5]);
+        CoNLLUFeatures features = new CoNLLUFeatures(bits[5]);
         word.set(CoreAnnotations.CoNLLUFeats.class, features);
 
 
@@ -268,7 +268,7 @@ public class CoNLLUDocumentReader implements
         word.setValue(bits[1]);
 
         /* Parse features. */
-        TreeMap<String, String> features = CoNLLUUtils.parseFeatures(bits[5]);
+        CoNLLUFeatures features = new CoNLLUFeatures(bits[5]);
         word.set(CoreAnnotations.CoNLLUFeats.class, features);
 
         /* Parse extra dependencies. */

--- a/src/edu/stanford/nlp/trees/ud/CoNLLUDocumentWriter.java
+++ b/src/edu/stanford/nlp/trees/ud/CoNLLUDocumentWriter.java
@@ -90,7 +90,7 @@ public class CoNLLUDocumentWriter {
 
             String additionalDepsString =  CoNLLUUtils.toExtraDepsString(enhancedDependencies);
             String word = token.word();
-            String featuresString = CoNLLUUtils.toFeatureString(token.get(CoreAnnotations.CoNLLUFeats.class));
+            String featuresString = CoNLLUFeatures.toFeatureString(token.get(CoreAnnotations.CoNLLUFeats.class));
             String pos = token.getString(CoreAnnotations.PartOfSpeechAnnotation.class, "_");
             String upos = token.getString(CoreAnnotations.CoarseTagAnnotation.class, "_");
             String misc = token.getString(CoreAnnotations.CoNLLUMisc.class, "_");
@@ -170,7 +170,7 @@ public class CoNLLUDocumentWriter {
           String upos = token.getString(CoreAnnotations.CoarseTagAnnotation.class, "_");
           String lemma = token.getString(CoreAnnotations.LemmaAnnotation.class, "_");
           String pos = token.getString(CoreAnnotations.PartOfSpeechAnnotation.class, "_");
-          String featuresString = CoNLLUUtils.toFeatureString(token.get(CoreAnnotations.CoNLLUFeats.class));
+          String featuresString = CoNLLUFeatures.toFeatureString(token.get(CoreAnnotations.CoNLLUFeats.class));
           String misc = token.getString(CoreAnnotations.CoNLLUMisc.class, "_");
           final String head;
           final String rel;

--- a/src/edu/stanford/nlp/trees/ud/CoNLLUFeatures.java
+++ b/src/edu/stanford/nlp/trees/ud/CoNLLUFeatures.java
@@ -15,6 +15,23 @@ import java.util.TreeMap;
  * which is necessary for the CoNLLU format
  */
 public class CoNLLUFeatures extends TreeMap<String, String> {
+  public static class LowercaseComparator implements Comparator<String> {
+    public int compare(String x, String y) {
+      if (x == null && y == null) {
+        return 0;
+      }
+      if (x == null) {
+        return -1;
+      }
+      if (y == null) {
+        return 1;
+      }
+      return x.compareToIgnoreCase(y);
+    }
+  }
+
+  static final LowercaseComparator comparator = new LowercaseComparator();
+
   /**
    * Parses the value of the feature column in a CoNLL-U file
    * and returns them in a HashMap with the feature names as keys
@@ -24,7 +41,7 @@ public class CoNLLUFeatures extends TreeMap<String, String> {
    * @return A {@code HashMap<String,String>} with the feature values.
    */
   public CoNLLUFeatures(String featureString) {
-    super();
+    super(comparator);
 
     if (!featureString.equals("_")) {
       String[] featValPairs = featureString.split("\\|");
@@ -36,11 +53,12 @@ public class CoNLLUFeatures extends TreeMap<String, String> {
   }
 
   public CoNLLUFeatures(Map<String, String> features) {
-    super(features);
+    super(comparator);
+    putAll(features);
   }
 
   public CoNLLUFeatures() {
-    super();
+    super(comparator);
   }
 
 

--- a/src/edu/stanford/nlp/trees/ud/CoNLLUFeatures.java
+++ b/src/edu/stanford/nlp/trees/ud/CoNLLUFeatures.java
@@ -1,0 +1,89 @@
+package edu.stanford.nlp.trees.ud;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * A subclass of TreeMap with a toString() that looks like a CoNLLUFeatures
+ * and a method for extracting the features from a CoNLLU string
+ * <br>
+ * This is a TreeMap so that the features are sorted by their key,
+ * which is necessary for the CoNLLU format
+ */
+public class CoNLLUFeatures extends TreeMap<String, String> {
+  /**
+   * Parses the value of the feature column in a CoNLL-U file
+   * and returns them in a HashMap with the feature names as keys
+   * and the feature values as values.
+   *
+   * @param featureString
+   * @return A {@code HashMap<String,String>} with the feature values.
+   */
+  public CoNLLUFeatures(String featureString) {
+    super();
+
+    if (!featureString.equals("_")) {
+      String[] featValPairs = featureString.split("\\|");
+      for (String p : featValPairs) {
+        String[] featValPair = p.split("=");
+        this.put(featValPair[0], featValPair[1]);
+      }
+    }
+  }
+
+  public CoNLLUFeatures(Map<String, String> features) {
+    super(features);
+  }
+
+  public CoNLLUFeatures() {
+    super();
+  }
+
+
+  public static class FeatureNameComparator implements Comparator<String> {
+    @Override
+    public int compare(String featureName1, String featureName2) {
+      return featureName1.toLowerCase().compareTo(featureName2.toLowerCase());
+    }
+  }
+
+  /**
+   * Converts the features to a feature string to be used
+   * in a CoNLL-U file.
+   *
+   * @return The feature string.
+   */
+  public static String toFeatureString(Map<String,String> features) {
+    StringBuilder sb = new StringBuilder();
+    boolean first = true;
+    if (features != null) {
+      List<String> sortedKeys = new ArrayList<>(features.keySet());
+      Collections.sort(sortedKeys, new FeatureNameComparator());
+      for (String key : sortedKeys) {
+        if (!first) {
+          sb.append("|");
+        } else {
+          first = false;
+        }
+        sb.append(key)
+          .append("=")
+          .append(features.get(key));
+        
+      }
+    }
+    /* Empty feature list. */
+    if (first) {
+      sb.append("_");
+    }
+
+    return sb.toString();
+  }
+
+  public String toString() {
+    return toFeatureString(this);
+  }
+}

--- a/src/edu/stanford/nlp/trees/ud/CoNLLUUtils.java
+++ b/src/edu/stanford/nlp/trees/ud/CoNLLUUtils.java
@@ -35,7 +35,7 @@ public class CoNLLUUtils {
      *
      * @return The feature string.
      */
-    public static String toFeatureString(HashMap<String,String> features) {
+    public static String toFeatureString(Map<String,String> features) {
         StringBuilder sb = new StringBuilder();
         boolean first = true;
         if (features != null) {

--- a/src/edu/stanford/nlp/trees/ud/CoNLLUUtils.java
+++ b/src/edu/stanford/nlp/trees/ud/CoNLLUUtils.java
@@ -10,60 +10,6 @@ import java.util.*;
 public class CoNLLUUtils {
 
     /**
-     * Parses the value of the feature column in a CoNLL-U file
-     * and returns them in a HashMap with the feature names as keys
-     * and the feature values as values.
-     *
-     * @param featureString
-     * @return A {@code HashMap<String,String>} with the feature values.
-     */
-    public static TreeMap<String,String> parseFeatures(String featureString) {
-        TreeMap<String, String> features = new TreeMap<>();
-        if (! featureString.equals("_")) {
-            String[] featValPairs = featureString.split("\\|");
-            for (String p : featValPairs) {
-                String[] featValPair = p.split("=");
-                features.put(featValPair[0], featValPair[1]);
-            }
-        }
-        return features;
-    }
-
-    /**
-     * Converts a feature HashMap to a feature string to be used
-     * in a CoNLL-U file.
-     *
-     * @return The feature string.
-     */
-    public static String toFeatureString(Map<String,String> features) {
-        StringBuilder sb = new StringBuilder();
-        boolean first = true;
-        if (features != null) {
-            List<String> sortedKeys = new ArrayList<>(features.keySet());
-            Collections.sort(sortedKeys, new FeatureNameComparator());
-            for (String key : sortedKeys) {
-                if (!first) {
-                    sb.append("|");
-                } else {
-                    first = false;
-                }
-
-                sb.append(key)
-                        .append("=")
-                        .append(features.get(key));
-
-            }
-        }
-
-    /* Empty feature list. */
-        if (first) {
-            sb.append("_");
-        }
-
-        return sb.toString();
-    }
-
-    /**
      * Parses the value of the extra dependencies column in a CoNLL-U file
      * and returns them in a HashMap with the governor indices as keys
      * and the relation names as values.
@@ -117,14 +63,6 @@ public class CoNLLUUtils {
         return sb.toString();
     }
 
-
-    public static class FeatureNameComparator implements Comparator<String> {
-
-        @Override
-        public int compare(String featureName1, String featureName2) {
-            return featureName1.toLowerCase().compareTo(featureName2.toLowerCase());
-        }
-    }
 
     public static class DepIndexComparator implements Comparator<String> {
 

--- a/src/edu/stanford/nlp/trees/ud/CoNLLUUtils.java
+++ b/src/edu/stanford/nlp/trees/ud/CoNLLUUtils.java
@@ -17,8 +17,8 @@ public class CoNLLUUtils {
      * @param featureString
      * @return A {@code HashMap<String,String>} with the feature values.
      */
-    public static HashMap<String,String> parseFeatures(String featureString) {
-        HashMap<String, String> features = new LinkedHashMap<>();
+    public static TreeMap<String,String> parseFeatures(String featureString) {
+        TreeMap<String, String> features = new TreeMap<>();
         if (! featureString.equals("_")) {
             String[] featValPairs = featureString.split("\\|");
             for (String p : featValPairs) {

--- a/src/edu/stanford/nlp/trees/ud/UniversalDependenciesFeatureAnnotator.java
+++ b/src/edu/stanford/nlp/trees/ud/UniversalDependenciesFeatureAnnotator.java
@@ -53,8 +53,8 @@ public class UniversalDependenciesFeatureAnnotator  {
 
 
   private static final String FEATURE_MAP_FILE = "edu/stanford/nlp/models/ud/feature_map.txt";
-  private HashMap<String,TreeMap<String,String>> posFeatureMap;
-  private Map<String,TreeMap<String,String>> wordPosFeatureMap;
+  private HashMap<String,CoNLLUFeatures> posFeatureMap;
+  private Map<String,CoNLLUFeatures> wordPosFeatureMap;
 
   private final Morphology morphology = new Morphology();
 
@@ -78,9 +78,9 @@ public class UniversalDependenciesFeatureAnnotator  {
         if (parts.length < 3) continue;
 
         if (parts[0].equals("*")) {
-          posFeatureMap.put(parts[1], CoNLLUUtils.parseFeatures(parts[2]));
+          posFeatureMap.put(parts[1], new CoNLLUFeatures(parts[2]));
         } else {
-          wordPosFeatureMap.put(parts[0] + '_' + parts[1], CoNLLUUtils.parseFeatures(parts[2]));
+          wordPosFeatureMap.put(parts[0] + '_' + parts[1], new CoNLLUFeatures(parts[2]));
         }
       }
     } catch (IOException e) {
@@ -392,10 +392,10 @@ public class UniversalDependenciesFeatureAnnotator  {
       String posTag = word.get(CoreAnnotations.PartOfSpeechAnnotation.class);
       String token = word.get(CoreAnnotations.TextAnnotation.class);
       Integer index = word.get(CoreAnnotations.IndexAnnotation.class);
-      TreeMap<String, String> wordFeatures = word.get(CoreAnnotations.CoNLLUFeats.class);
+      CoNLLUFeatures wordFeatures = word.get(CoreAnnotations.CoNLLUFeats.class);
 
       if (wordFeatures == null) {
-        wordFeatures = new TreeMap<>();
+        wordFeatures = new CoNLLUFeatures();
         word.set(CoreAnnotations.CoNLLUFeats.class, wordFeatures);
       }
 

--- a/src/edu/stanford/nlp/trees/ud/UniversalDependenciesFeatureAnnotator.java
+++ b/src/edu/stanford/nlp/trees/ud/UniversalDependenciesFeatureAnnotator.java
@@ -7,8 +7,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeMap;
 
 import edu.stanford.nlp.io.IOUtils;
 import edu.stanford.nlp.io.RuntimeIOException;
@@ -51,8 +53,8 @@ public class UniversalDependenciesFeatureAnnotator  {
 
 
   private static final String FEATURE_MAP_FILE = "edu/stanford/nlp/models/ud/feature_map.txt";
-  private HashMap<String,HashMap<String,String>> posFeatureMap;
-  private HashMap<String,HashMap<String,String>> wordPosFeatureMap;
+  private HashMap<String,TreeMap<String,String>> posFeatureMap;
+  private Map<String,TreeMap<String,String>> wordPosFeatureMap;
 
   private final Morphology morphology = new Morphology();
 
@@ -390,10 +392,10 @@ public class UniversalDependenciesFeatureAnnotator  {
       String posTag = word.get(CoreAnnotations.PartOfSpeechAnnotation.class);
       String token = word.get(CoreAnnotations.TextAnnotation.class);
       Integer index = word.get(CoreAnnotations.IndexAnnotation.class);
-      HashMap<String, String> wordFeatures = word.get(CoreAnnotations.CoNLLUFeats.class);
+      TreeMap<String, String> wordFeatures = word.get(CoreAnnotations.CoNLLUFeats.class);
 
       if (wordFeatures == null) {
-        wordFeatures = new HashMap<>();
+        wordFeatures = new TreeMap<>();
         word.set(CoreAnnotations.CoNLLUFeats.class, wordFeatures);
       }
 

--- a/test/src/edu/stanford/nlp/semgraph/semgrex/ssurgeon/SsurgeonTest.java
+++ b/test/src/edu/stanford/nlp/semgraph/semgrex/ssurgeon/SsurgeonTest.java
@@ -1449,7 +1449,7 @@ public class SsurgeonTest {
 
 
   /**
-   * Put MWT annotations on a couple nodes using EditNode
+   * Put MWT annotations on a couple nodes using CombineMWT
    */
   @Test
   public void readXMLCombineMWT() {


### PR DESCRIPTION
Add some better support for morphological features to semgrex & ssurgeon.  In particular, ssurgeon now allows for updating individual features rather than updating the entire block at once.  Furthermore, the internal representation now alphabetizes the features, and by default empty features will output as `_`