### PR TITLE
Remove json-simple from POM files

### DIFF
--- a/doc/corenlp/pom-full.xml
+++ b/doc/corenlp/pom-full.xml
@@ -189,13 +189,6 @@
       <version>2.4.0-b180830.0438</version>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple -->
-    <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>1.1.1</version>
-    </dependency>
-
   </dependencies>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/pom-java-11.xml
+++ b/pom-java-11.xml
@@ -187,13 +187,6 @@
       <version>2.4.0-b180830.0438</version>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple -->
-    <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>1.1.1</version>
-    </dependency>
-
   </dependencies>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/pom-java-17.xml
+++ b/pom-java-17.xml
@@ -187,13 +187,6 @@
       <version>2.4.0-b180830.0438</version>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple -->
-    <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>1.1.1</version>
-    </dependency>
-
   </dependencies>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -189,13 +189,6 @@
       <version>2.4.0-b180830.0438</version>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple -->
-    <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>1.1.1</version>
-    </dependency>
-
   </dependencies>
   <build>
     <sourceDirectory>src</sourceDirectory>


### PR DESCRIPTION
Remove json-simple dependency from POM files, as it is no longer used.

This diff is in the public domain.