### PR TITLE
fix(io): use `Thread.currentThread().getContextClassLoader()` instead of system class loader when loading resources

### DIFF
--- a/src/edu/stanford/nlp/io/IOUtils.java
+++ b/src/edu/stanford/nlp/io/IOUtils.java
@@ -405,33 +405,36 @@ public class IOUtils  {
 
   /**
    * Locates a file in the CLASSPATH if it exists.  Checks both the
-   * System classloader and the IOUtils classloader, since we had
+   * current thread context classloader which default to the system class classloader unless the user sets another
+   * classloader explicitly, then we fallaback to the IOUtils classloader, since we had
    * separate users asking for both of those changes.
    */
   private static InputStream findStreamInClassLoader(String name) {
-    InputStream is = ClassLoader.getSystemResourceAsStream(name);
+    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+    InputStream is = contextClassLoader.getResourceAsStream(name);
     if (is != null)
       return is;
 
     // windows File.separator is \, but getting resources only works with /
-    is = ClassLoader.getSystemResourceAsStream(name.replaceAll("\\\\", "/"));
+    is = contextClassLoader.getResourceAsStream(name.replaceAll("\\\\", "/"));
     if (is != null)
       return is;
 
     // Classpath doesn't like double slashes (e.g., /home/user//foo.txt)
-    is = ClassLoader.getSystemResourceAsStream(name.replaceAll("\\\\", "/").replaceAll("/+", "/"));
+    is = contextClassLoader.getResourceAsStream(name.replaceAll("\\\\", "/").replaceAll("/+", "/"));
     if (is != null)
       return is;
 
-    is = IOUtils.class.getClassLoader().getResourceAsStream(name);
+    ClassLoader fallbackClassLoader = IOUtils.class.getClassLoader();
+    is = fallbackClassLoader.getResourceAsStream(name);
     if (is != null)
       return is;
 
-    is = IOUtils.class.getClassLoader().getResourceAsStream(name.replaceAll("\\\\", "/"));
+    is = fallbackClassLoader.getResourceAsStream(name.replaceAll("\\\\", "/"));
     if (is != null)
       return is;
 
-    is = IOUtils.class.getClassLoader().getResourceAsStream(name.replaceAll("\\\\", "/").replaceAll("/+", "/"));
+    is = fallbackClassLoader.getResourceAsStream(name.replaceAll("\\\\", "/").replaceAll("/+", "/"));
     // at this point we've tried everything
     return is;
   }


### PR DESCRIPTION
# Bug description

This PR is related to #1051, where the goal was to be able to load resource when a different classloader was set at the JVM start.

This PR aims at generalizing the fix when the classloader it dynamically set for the current thread by the user like this:

```java
downloadModels(path) // download models at runtime
MyDynamicClassLoaderImpl loader = new MyDynamicClassLoaderImpl() // define a loader for the current thread to be able to load models without restarting the JVM
loader.addUrl(path.toURI().toURL()) // This make the model available to the dynamic loader
Thread.currentThread().setContextClassLoader(new MyDynamicClassLoaderImpl()) // Set the loader for the current thread, this same loader will be retrieverd by the IOUtils later
StanfordCoreNLP pipeline = new StanfordCoreNLP() // Loade the model
```

This PR won't change anything for users which don't use any dynamic loader since the IOUtils do:
```java
Thread.currentThread().getContextClassLoader()
```
which be default should return the system classloader.

In case the user have set a loader for the thread then this loader will be used and by convention will delegate resource finding to its parent (which at some point will be the system classloader).

# Changes

## `io`

### Fixed
- use `Thread.currentThread().getContextClassLoader().getResourceAsStream` instead of ` ClassLoader.getSystemResourceAsStream` in `IOUtils`
